### PR TITLE
Add Lock.LockWithData

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -39,10 +39,16 @@ func parseSeq(path string) (int, error) {
 	return strconv.Atoi(parts[len(parts)-1])
 }
 
-// Lock attempts to acquire the lock. It will wait to return until the lock
-// is acquired or an error occurs. If this instance already has the lock
-// then ErrDeadlock is returned.
+// Lock attempts to acquire the lock. It works like LockWithData, but it doesn't
+// write any data to the lock node.
 func (l *Lock) Lock() error {
+	return l.LockWithData([]byte{})
+}
+
+// LockWithData attempts to acquire the lock, writing data into the lock node.
+// It will wait to return until the lock is acquired or an error occurs. If
+// this instance already has the lock then ErrDeadlock is returned.
+func (l *Lock) LockWithData(data []byte) error {
 	if l.lockPath != "" {
 		return ErrDeadlock
 	}
@@ -52,7 +58,7 @@ func (l *Lock) Lock() error {
 	path := ""
 	var err error
 	for i := 0; i < 3; i++ {
-		path, err = l.c.CreateProtectedEphemeralSequential(prefix, []byte{}, l.acl)
+		path, err = l.c.CreateProtectedEphemeralSequential(prefix, data, l.acl)
 		if err == ErrNoNode {
 			// Create parent node.
 			parts := strings.Split(l.path, "/")


### PR DESCRIPTION
LockWithData is a new method that allows creating a lock with a
specified content. This helps in scenarios where it's necessary to
correlate data to a lock, e.g. multiple systems contending a lock
and needing to know which one got it.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>