### PR TITLE
[lock] interoperate with Python client

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -36,6 +36,10 @@ func NewLock(c *Conn, path string, acl []ACL) *Lock {
 
 func parseSeq(path string) (int, error) {
 	parts := strings.Split(path, "-")
+	// python client uses a __LOCK__ prefix
+	if len(parts) == 1 {
+		parts = strings.Split(path, "__")
+	}
 	return strconv.Atoi(parts[len(parts)-1])
 }
 

--- a/lock_test.go
+++ b/lock_test.go
@@ -93,3 +93,28 @@ func TestMultiLevelLock(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestParseSeq(t *testing.T) {
+	const (
+		goLock = "_c_38553bd6d1d57f710ae70ddcc3d24715-lock-0000000000"
+		pyLock = "da5719988c244fc793f49ec3aa29b566__lock__0000000003"
+	)
+
+	seq, err := parseSeq(goLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if seq != 0 {
+		t.Fatalf("Expected 0 instead of %d", seq)
+	}
+
+	seq, err = parseSeq(pyLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if seq != 3 {
+		t.Fatalf("Expected 3 instead of %d", seq)
+	}
+}


### PR DESCRIPTION
I got the following error message while using the library:

```
strconv.Atoi: parsing \"640f65557dc046648b51a144f37fc95d__lock__0000196658\": invalid syntax"
```

Which led me to finding https://github.com/python-zk/kazoo/issues/548.

Apparently the Go and Python client libraries use a different prefix and don't work well with each other.

I haven't tested the PR yet. I am putting it up for comments to see if it makes sense.