### PR TITLE
remove codecov token

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -30,7 +30,6 @@ jobs:
         run: make test
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v1.0.0
+        uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./profile.cov


### PR DESCRIPTION
I was getting the following error:

```
Please provide an upload token from codecov.io with valid arguments
```

From https://github.com/codecov/codecov-action

```
For public repositories, no token is needed
```

Fixes #20 