### PR TITLE
bump versions

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -3,3 +3,6 @@ coverage:
     patch:
       default:
         target: 75%
+    project:
+      default:
+        threshold: 1%

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -6,8 +6,8 @@ jobs:
     name: unittest
     strategy:
       matrix:
-        zk-version: [3.4.14, 3.5.6]
-        go-version: [1.11.x, 1.12.x, 1.13.x]
+        zk-version: [3.5.8, 3.6.1]
+        go-version: [1.13.x, 1.14.x]
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
@@ -18,16 +18,13 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.9
+          java-version: 14
 
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Setup code
-        run: make setup ZK_VERSION=${{ matrix.zk-version }}
-
       - name: Test code
-        run: make test
+        run: make test ZK_VERSION=${{ matrix.zk-version }}
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v1

--- a/flw.go
+++ b/flw.go
@@ -24,7 +24,7 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 	// different parts of the regular expression that are required to parse the srvr output
 	const (
 		zrVer   = `^Zookeeper version: ([A-Za-z0-9\.\-]+), built on (\d\d/\d\d/\d\d\d\d \d\d:\d\d [A-Za-z0-9:\+\-]+)`
-		zrLat   = `^Latency min/avg/max: (\d+)/(\d+)/(\d+)`
+		zrLat   = `^Latency min/avg/max: (\d+)/([0-9.]+)/(\d+)`
 		zrNet   = `^Received: (\d+).*\n^Sent: (\d+).*\n^Connections: (\d+).*\n^Outstanding: (\d+)`
 		zrState = `^Zxid: (0x[A-Za-z0-9]+).*\n^Mode: (\w+).*\n^Node count: (\d+)`
 	)
@@ -97,7 +97,7 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 		// within the regex above, these values must be numerical
 		// so we can avoid useless checking of the error return value
 		minLatency, _ := strconv.ParseInt(match[2], 0, 64)
-		avgLatency, _ := strconv.ParseInt(match[3], 0, 64)
+		avgLatency, _ := strconv.ParseFloat(match[3], 64)
 		maxLatency, _ := strconv.ParseInt(match[4], 0, 64)
 		recv, _ := strconv.ParseInt(match[5], 0, 64)
 		sent, _ := strconv.ParseInt(match[6], 0, 64)

--- a/structs.go
+++ b/structs.go
@@ -78,7 +78,7 @@ type ServerStats struct {
 	Received    int64
 	NodeCount   int64
 	MinLatency  int64
-	AvgLatency  int64
+	AvgLatency  float64
 	MaxLatency  int64
 	Connections int64
 	Outstanding int64


### PR DESCRIPTION
* bump ZooKeeper, Go and Java versions
* pass ZK_VERSION when running tests
* FLW latency average can be a float instead of an int
* Update codecov project threshold