### PR TITLE
cluster_test: add sync

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -39,6 +39,10 @@ func TestBasicCluster(t *testing.T) {
 		t.Fatalf("Create failed on node 1: %+v", err)
 	}
 
+	if _, err := zk2.Sync("/gozk-test"); err != nil {
+		t.Fatalf("Sync failed on node 2: %+v", err)
+	}
+
 	if by, _, err := zk2.Get("/gozk-test"); err != nil {
 		t.Fatalf("Get failed on node 2: %+v", err)
 	} else if string(by) != "foo-cluster" {


### PR DESCRIPTION
From the [docs](https://zookeeper.apache.org/doc/r3.6.1/zookeeperProgrammers.html):

> If it is important that Client A and Client B read the same value, Client B should call the sync() method from the ZooKeeper API method before it performs its read.

This is an attempt to fix one of the flaky tests mentioned in #17:

```
--- FAIL: TestBasicCluster (11.20s)
##[error]    cluster_test.go:15: [ZKERR] ZooKeeper JMX enabled by default
##[error]    cluster_test.go:15: [ZKERR] ZooKeeper JMX enabled by default
##[error]    cluster_test.go:15: [ZKERR] ZooKeeper JMX enabled by default
##[error]    cluster_test.go:15: [ZKERR] Using config: /tmp/gozk770506775/srv3/zoo.cfg
##[error]    cluster_test.go:15: [ZKERR] Using config: /tmp/gozk770506775/srv2/zoo.cfg
##[error]    cluster_test.go:15: [ZKERR] Using config: /tmp/gozk770506775/srv1/zoo.cfg
##[error]    cluster_test.go:43: Get failed on node 2: zk: node does not exist
```