### PR TITLE
Global EventNotWatching events for session lost

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -534,6 +534,7 @@ func (c *Conn) invalidateWatches(err error) {
 	if len(c.watchers) >= 0 {
 		for pathType, watchers := range c.watchers {
 			ev := Event{Type: EventNotWatching, State: StateDisconnected, Path: pathType.path, Err: err}
+			c.sendEvent(ev) // also publish globally
 			for _, ch := range watchers {
 				ch <- ev
 				close(ch)


### PR DESCRIPTION
All other events are published to the global event callback; but lost session events are not.  These events are essential to correctly implement cross-cutting wrapper frameworks that do things like re-add watches when a new session is obtained.