### PR TITLE
Update conn.go

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1068,7 +1068,7 @@ func (c *Conn) CreateTTL(path string, data []byte, flags int32, acl []ACL, ttl t
 	}
 
 	res := &createResponse{}
-	_, err := c.request(opCreateTTL, &CreateTTLRequest{path, data, acl, flags, ttl.Milliseconds()}, res, nil)
+	_, err := c.request(opCreateTTL, &CreateTTLRequest{path, data, acl, flags, int64(ttl) / 1e6}, res, nil)
 	return res.Path, err
 }
 


### PR DESCRIPTION
The `Millisecond()` function of `time.Duration` is supported from go version 1.13 and above.
Therefore, modified to perform the same operation without using the method for compatibility with versions below.