### PR TITLE
ignoring non-lock nodes when processing for lockWithData

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -107,6 +107,10 @@ func (l *Lock) LockWithData(data []byte) error {
 		prevSeq := -1
 		prevSeqPath := ""
 		for _, p := range children {
+      if !(strings.HasPrefix(p, protectedPrefix) || strings.Contains(strings.ToUpper(p), "__LOCK__")) {
+        // no need to process nodes which are not lock nodes
+        continue
+      }
 			s, err := parseSeq(p)
 			if err != nil {
 				return err

--- a/lock_test.go
+++ b/lock_test.go
@@ -118,3 +118,53 @@ func TestParseSeq(t *testing.T) {
 		t.Fatalf("Expected 3 instead of %d", seq)
 	}
 }
+
+func TestParentMultiLevelLock(t *testing.T) {
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk, _, err := ts.ConnectAll()
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	defer zk.Close()
+
+	acls := WorldACL(PermAll)
+	path := "/test-multi-level"
+	if p, err := zk.Create(path, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
+		t.Fatalf("Create returned error: %+v", err)
+	} else if p != path {
+		t.Fatalf("Create returned different path '%s' != '%s'", p, path)
+	}
+	// create path with integer leaf
+	path = "/test-multi-level/1"
+	if p, err := zk.Create(path, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
+		t.Fatalf("Create returned error: %+v", err)
+	} else if p != path {
+		t.Fatalf("Create returned different path '%s' != '%s'", p, path)
+	}
+	//create node at the parent of /1 node
+	l := NewLock(zk, "/test-multi-level", acls)
+
+	defer zk.Delete("/test-multi-level", -1) // Clean up what we've created for this test
+	defer zk.Delete("/test-multi-level/1", -1)
+
+	if err := l.Lock(); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+
+	// create lock again to see that it works again
+	newLock := NewLock(zk, "/test-multi-level", acls)
+	if err := newLock.Lock(); err != nil {
+		t.Fatal(err)
+	}
+	if err := newLock.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
there is a problems when nodes at lock node level where protected Ephemeral nodes are created have user created nodes as well. lockWithData function tries to use those user created node to calculate sequence number and it fails or stuck .

1. Fails : when user created node is not an integer
2. Stuck : when user created not have a sequence number less than current lock sequence number.