### PR TITLE
Optimize comparison

### DIFF
--- a/flw.go
+++ b/flw.go
@@ -138,7 +138,7 @@ func FLWRuok(servers []string, timeout time.Duration) []bool {
 			continue
 		}
 
-		if bytes.Equal(response[:4], []byte("imok")) {
+		if string(response[:4]) == "imok" {
 			oks[i] = true
 		}
 	}


### PR DESCRIPTION
```go
func BenchmarkCompare(b *testing.B) {
	var response = []byte("imokres")
	b.Run("1", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			if bytes.Equal(response[:4], []byte("imok")) {

			}
		}
	})
	b.Run("2", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			if string(response[:4]) == "imok" {
			}
		}
	})
}
```

```
cpu: Intel(R) Core(TM) i5-7600 CPU @ 3.50GHz
BenchmarkCompare
BenchmarkCompare/1
BenchmarkCompare/1-4 	195669936	         5.736 ns/op	       0 B/op	       0 allocs/op
BenchmarkCompare/2
BenchmarkCompare/2-4 	1000000000	         0.2531 ns/op	       0 B/op	       0 allocs/op
PASS
```