### PR TITLE
Update connection structs to avoid read only warning from server

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -149,6 +149,7 @@ type connectRequest struct {
 	TimeOut         int32
 	SessionID       int64
 	Passwd          []byte
+	ReadOnly	bool
 }
 
 type connectResponse struct {
@@ -156,6 +157,7 @@ type connectResponse struct {
 	TimeOut         int32
 	SessionID       int64
 	Passwd          []byte
+	ReadOnly 	bool
 }
 
 type CreateRequest struct {

--- a/structs_test.go
+++ b/structs_test.go
@@ -8,8 +8,8 @@ import (
 func TestEncodeDecodePacket(t *testing.T) {
 	t.Parallel()
 	encodeDecodeTest(t, &requestHeader{-2, 5})
-	encodeDecodeTest(t, &connectResponse{1, 2, 3, nil})
-	encodeDecodeTest(t, &connectResponse{1, 2, 3, []byte{4, 5, 6}})
+	encodeDecodeTest(t, &connectResponse{1, 2, 3, nil, false})
+	encodeDecodeTest(t, &connectResponse{1, 2, 3, []byte{4, 5, 6}, false})
 	encodeDecodeTest(t, &getAclResponse{[]ACL{{12, "s", "anyone"}}, Stat{}})
 	encodeDecodeTest(t, &getChildrenResponse{[]string{"foo", "bar"}})
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})


### PR DESCRIPTION
Using a ZK server in version 3.4.9 I always have a warning when my app is connecting to it. I believe this is due to this bit of code in the ZK codebase:
`
        boolean readOnly = false;
        try {
            readOnly = bia.readBool("readOnly");
            cnxn.isOldClient = false;
        } catch (IOException e) {
            // this is ok -- just a packet from an old client which
            // doesn't contain readOnly field
            LOG.warn("Connection request from old client "
                    + cnxn.getRemoteSocketAddress()
                    + "; will be dropped if server is in r-o mode");
        }
`

ZK now allows the addition of a flag for "ReadOnly" mode, if the client doesn't give this flag it will trigger a warning. If the server is in read-only mode & there's no readOnly field, the connection will we dropped. 

The goal of this PR is to avoid triggering this warning, by passing a readOnly always setted to false. I think this can be a first step to handling readOnly ZK server.