### PR TITLE
Allow reconnection to a session from a saved session id and passwd

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -311,6 +311,8 @@ func WithMaxConnBufferSize(maxBufferSize int) connOption {
 	}
 }
 
+// WithSessionIdAndPasswd sets the session id and password to be used
+// for the first connection attempt
 func WithSessionIdAndPasswd(sessionID int64, passwd []byte) connOption{
 	return func(c *Conn) {
 		c.sessionID = sessionID

--- a/conn.go
+++ b/conn.go
@@ -99,7 +99,7 @@ type Conn struct {
 	watchers     map[watchPathType][]chan Event
 	watchersLock sync.Mutex
 	closeChan    chan struct{} // channel to tell send loop stop
-	sessionLock sync.RWMutex
+	sessionLock  sync.RWMutex
 
 	// Debug (used by unit tests)
 	reconnectLatch   chan struct{}
@@ -313,7 +313,7 @@ func WithMaxConnBufferSize(maxBufferSize int) connOption {
 
 // WithSessionIdAndPasswd sets the session id and password to be used
 // for the first connection attempt
-func WithSessionIdAndPasswd(sessionID int64, passwd []byte) connOption{
+func WithSessionIdAndPasswd(sessionID int64, passwd []byte) connOption {
 	return func(c *Conn) {
 		c.sessionID = sessionID
 		c.passwd = passwd
@@ -345,7 +345,7 @@ func (c *Conn) SessionID() int64 {
 	return c.sessionID
 }
 
-// Password returns the current session password of the connection.
+// SessionPassword returns the current session password of the connection.
 func (c *Conn) SessionPasswd() []byte {
 	c.sessionLock.RLock()
 	defer c.sessionLock.RUnlock()

--- a/server_java_test.go
+++ b/server_java_test.go
@@ -168,6 +168,4 @@ func waitForSession(ctx context.Context, eventChan <-chan Event) error {
 			return ctx.Err()
 		}
 	}
-
-	return nil
 }

--- a/server_java_test.go
+++ b/server_java_test.go
@@ -153,18 +153,20 @@ func (sc ServerConfig) Marshall(w io.Writer) error {
 
 // this is a helper to wait for the zk connection to at least get to the HasSession state
 func waitForSession(ctx context.Context, eventChan <-chan Event) error {
-	select {
-	case event, ok := <-eventChan:
-		// The eventChan is used solely to determine when the ZK conn has
-		// stopped.
-		if !ok {
-			return fmt.Errorf("connection closed before state reached")
+	for {
+		select {
+		case event, ok := <-eventChan:
+			// The eventChan is used solely to determine when the ZK conn has
+			// stopped.
+			if !ok {
+				return fmt.Errorf("connection closed before state reached")
+			}
+			if event.State == StateHasSession {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-		if event.State == StateHasSession {
-			return nil
-		}
-	case <-ctx.Done():
-		return ctx.Err()
 	}
 
 	return nil

--- a/zk_test.go
+++ b/zk_test.go
@@ -1112,6 +1112,62 @@ func TestMaxBufferSize(t *testing.T) {
 	}
 }
 
+func TestSessionReconnectionFromSavedID(t *testing.T) {
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk, eventChan, err := ts.ConnectAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zk.Close()
+	// Prevent reconnection from this client
+	zk.reconnectLatch = make(chan struct{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	err = waitForSession(ctx, eventChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := zk.SessionID()
+	passwd := zk.SessionPasswd()
+
+	// Simulate network error by brutally closing the network connection.
+	_ = zk.conn.Close()
+
+
+	// Re-establish the session from a different client with the session id and passwd
+	zk, eventChan, err = ts.ConnectWithOptions(15*time.Second, WithSessionIdAndPasswd(sessionID, append(passwd)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zk.Close()
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	err = waitForSession(ctx, eventChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID2 := zk.SessionID()
+	passwd2 := zk.SessionPasswd()
+
+	if sessionID != sessionID2 {
+		t.Fatalf("session id mismatch: %d %d", sessionID, sessionID2)
+	}
+
+	if !reflect.DeepEqual(passwd, passwd2) {
+		t.Fatalf("session password mismatch: %v %v", passwd, passwd2)
+	}
+}
+
+
 func startSlowProxy(t *testing.T, up, down Rate, upstream string, adj func(ln *Listener)) (string, chan bool, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/zk_test.go
+++ b/zk_test.go
@@ -1140,7 +1140,6 @@ func TestSessionReconnectionFromSavedID(t *testing.T) {
 	// Simulate network error by brutally closing the network connection.
 	_ = zk.conn.Close()
 
-
 	// Re-establish the session from a different client with the session id and passwd
 	zk, eventChan, err = ts.ConnectWithOptions(15*time.Second, WithSessionIdAndPasswd(sessionID, passwd))
 	if err != nil {
@@ -1166,7 +1165,6 @@ func TestSessionReconnectionFromSavedID(t *testing.T) {
 		t.Fatalf("session password mismatch: %v %v", passwd, passwd2)
 	}
 }
-
 
 func startSlowProxy(t *testing.T, up, down Rate, upstream string, adj func(ln *Listener)) (string, chan bool, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/zk_test.go
+++ b/zk_test.go
@@ -1142,7 +1142,7 @@ func TestSessionReconnectionFromSavedID(t *testing.T) {
 
 
 	// Re-establish the session from a different client with the session id and passwd
-	zk, eventChan, err = ts.ConnectWithOptions(15*time.Second, WithSessionIdAndPasswd(sessionID, append(passwd)))
+	zk, eventChan, err = ts.ConnectWithOptions(15*time.Second, WithSessionIdAndPasswd(sessionID, passwd))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds a way to read the session id and session password from an established session and to provide them as argument when creating a new connection, allowing to recover an existing session. (This mimicks what the java Zookeeper allows: https://zookeeper.apache.org/doc/r3.3.3/api/org/apache/zookeeper/ZooKeeper.html)

A possible use case for this is to store these values in persistent storage and re-establish a session after a process restart.

 Operations to get and set `passwd` are implemented with atomic operations on an unsafe pointer to be consistent with the atomic operations used for `sessionID` but I'm happy to change the PR to use a lock instead if that's preferable.

I have also made a small change to the `waitForSession` helper that I think is consistent with what the function tries to achieve.

Locally all the tests are passing except for `TestSetWatchers` but it also fails on master with the following error:
```
2021/08/12 16:38:09 connected to 127.0.0.1:14108
2021/08/12 16:38:09 connected to 127.0.0.1:14108
2021/08/12 16:38:09 authenticated: id=72088870267584512, timeout=10000
2021/08/12 16:38:09 authenticated: id=72088870267584513, timeout=10000
2021/08/12 16:38:09 re-submitting `0` credentials after reconnect
2021/08/12 16:38:09 re-submitting `0` credentials after reconnect
2021/08/12 16:38:29 recv loop terminated: failed to read from connection: read tcp 127.0.0.1:62986->127.0.0.1:14108: use of closed network connection
2021/08/12 16:38:29 send loop terminated: <nil>
2021/08/12 16:38:50 connected to 127.0.0.1:14108
2021/08/12 16:38:50 authentication failed: zk: session has been expired by the server
2021/08/12 16:38:51 connected to 127.0.0.1:14108
2021/08/12 16:38:51 authenticated: id=72088870267584514, timeout=10000
2021/08/12 16:38:51 re-submitting `0` credentials after reconnect
2021/08/12 16:39:10 recv loop terminated: EOF
2021/08/12 16:39:10 send loop terminated: <nil>
2021/08/12 16:39:10 recv loop terminated: EOF
2021/08/12 16:39:10 send loop terminated: <nil>
--- FAIL: TestSetWatchers (63.04s)
    cluster_test.go:15: [ZKERR] ZooKeeper JMX enabled by default
    cluster_test.go:15: [ZKERR] Using config: /var/folders/79/rrhrlc6d5f1gd1dqxvnl468h0000gn/T/gozk873519656/srv1/zoo.cfg
    zk_test.go:828: GetW watcher error zk: session has been expired by the server
FAIL
exit status 1
FAIL	github.com/go-zookeeper/zk	63.484s
```