### PR TITLE
Fix parseSeq incorrectly parsing negative sequence number

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -35,7 +35,7 @@ func NewLock(c *Conn, path string, acl []ACL) *Lock {
 }
 
 func parseSeq(path string) (int, error) {
-	parts := strings.Split(path, "-")
+	parts := strings.Split(path, "lock-")
 	// python client uses a __LOCK__ prefix
 	if len(parts) == 1 {
 		parts = strings.Split(path, "__")

--- a/lock_test.go
+++ b/lock_test.go
@@ -96,24 +96,31 @@ func TestMultiLevelLock(t *testing.T) {
 
 func TestParseSeq(t *testing.T) {
 	const (
-		goLock = "_c_38553bd6d1d57f710ae70ddcc3d24715-lock-0000000000"
-		pyLock = "da5719988c244fc793f49ec3aa29b566__lock__0000000003"
+		goLock       = "_c_38553bd6d1d57f710ae70ddcc3d24715-lock-0000000000"
+		negativeLock = "_c_38553bd6d1d57f710ae70ddcc3d24715-lock--2147483648"
+		pyLock       = "da5719988c244fc793f49ec3aa29b566__lock__0000000003"
 	)
 
 	seq, err := parseSeq(goLock)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if seq != 0 {
 		t.Fatalf("Expected 0 instead of %d", seq)
+	}
+
+	seq, err = parseSeq(negativeLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seq != -2147483648 {
+		t.Fatalf("Expected -2147483648 instead of %d", seq)
 	}
 
 	seq, err = parseSeq(pyLock)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if seq != 3 {
 		t.Fatalf("Expected 3 instead of %d", seq)
 	}


### PR DESCRIPTION
This PR includes a change to the `parseSeq` function used by the lock to parse sequence numbers. When the Zookeeper sequence number rolls over it rolls to -2147483647 rather than 0. `parseSeq` splits on a "-" symbol so when the path is split into parts the negative symbol is stripped away incorrectly. I changed this to split on the full prefix of "lock-" instead which saves the negative symbol. A test for this is included.