### PR TITLE
fix the set of events received by ChildrenW

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -801,7 +801,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 
 		if res.Xid == -1 {
 			res := &watcherEvent{}
-			_, err := decodePacket(buf[16:blen], res)
+			_, err = decodePacket(buf[16:blen], res)
 			if err != nil {
 				return err
 			}
@@ -816,15 +816,17 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 			switch res.Type {
 			case EventNodeCreated:
 				wTypes = append(wTypes, watchTypeExist)
-			case EventNodeDeleted, EventNodeDataChanged:
-				wTypes = append(wTypes, watchTypeExist, watchTypeData, watchTypeChild)
+			case EventNodeDataChanged:
+				wTypes = append(wTypes, watchTypeExist, watchTypeData)
 			case EventNodeChildrenChanged:
 				wTypes = append(wTypes, watchTypeChild)
+			case EventNodeDeleted:
+				wTypes = append(wTypes, watchTypeExist, watchTypeData, watchTypeChild)
 			}
 			c.watchersLock.Lock()
 			for _, t := range wTypes {
 				wpt := watchPathType{res.Path, t}
-				if watchers := c.watchers[wpt]; watchers != nil && len(watchers) > 0 {
+				if watchers := c.watchers[wpt]; len(watchers) > 0 {
 					for _, ch := range watchers {
 						ch <- ev
 						close(ch)


### PR DESCRIPTION
In accordance with
https://github.com/apache/zookeeper/blob/c74658d398cdc1d207aa296cb6e20de00faec03e/zookeeper-client/zookeeper-client-c/src/zk_hashtable.c#L297-L314
```c
    switch(type){
    case CREATED_EVENT_DEF:
    case CHANGED_EVENT_DEF:
        // look up the watchers for the path and move them to a delivery list
        add_for_event(zh->active_node_watchers,path,&list);
        add_for_event(zh->active_exist_watchers,path,&list);
        break;
    case CHILD_EVENT_DEF:
        // look up the watchers for the path and move them to a delivery list
        add_for_event(zh->active_child_watchers,path,&list);
        break;
    case DELETED_EVENT_DEF:
        // look up the watchers for the path and move them to a delivery list
        add_for_event(zh->active_node_watchers,path,&list);
        add_for_event(zh->active_exist_watchers,path,&list);
        add_for_event(zh->active_child_watchers,path,&list);
        break;
    }
 ```
ChildrenW should not receive data change events of the observed node.

I believe that this will fix https://github.com/go-zookeeper/zk/issues/38 and it will change the set of events received by ChildrenW described here https://github.com/go-zookeeper/zk/issues/56