### PR TITLE
Support context in lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.idea/
 .DS_Store
 profile.cov
 zookeeper

--- a/lock.go
+++ b/lock.go
@@ -1,6 +1,7 @@
 package zk
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -13,6 +14,8 @@ var (
 	ErrDeadlock = errors.New("zk: trying to acquire a lock twice")
 	// ErrNotLocked is returned by Unlock when trying to release a lock that has not first be acquired.
 	ErrNotLocked = errors.New("zk: not locked")
+	// ErrAcquireLockTimeout is returned by Lock when occur timeout.
+	ErrAcquireLockTimeout = errors.New("zk: timeout to acquire a lock")
 )
 
 const (
@@ -55,18 +58,31 @@ func parseSeq(path string) (int, error) {
 // Lock attempts to acquire the lock. It works like LockWithData, but it doesn't
 // write any data to the lock node.
 func (l *Lock) Lock() error {
-	return l.LockWithData([]byte{})
+	return l.LockContextWithData(context.Background(), []byte{})
+}
+
+// LockContext attempts to acquire the lock with the given context. It works like LockContextWithData, but it doesn't
+// write any data to the lock node.
+func (l *Lock) LockContext(ctx context.Context) error {
+	return l.LockContextWithData(ctx, []byte{})
 }
 
 // LockWithData attempts to acquire the lock, writing data into the lock node.
 // It will wait to return until the lock is acquired or an error occurs. If
 // this instance already has the lock then ErrDeadlock is returned.
 func (l *Lock) LockWithData(data []byte) error {
+	return l.LockContextWithData(context.Background(), data)
+}
+
+// LockContextWithData attempts to acquire the lock, writing data into the lock node.
+// It will wait to return until the lock is acquired or an error occurs, the context is done. If
+// this instance already has the lock then ErrDeadlock is returned.
+// ErrAcquireLockTimeout will also be returned if the given context is done.
+func (l *Lock) LockContextWithData(ctx context.Context, data []byte) error {
 	if !atomic.CompareAndSwapInt32(&l.state, lockStateNone, lockStateAcquiring) {
 		return ErrDeadlock
 	}
-
-	if err := l.lockWithData(data); err != nil {
+	if err := l.lockWithData(ctx, data); err != nil {
 		atomic.StoreInt32(&l.state, lockStateNone)
 		return err
 	}
@@ -74,12 +90,15 @@ func (l *Lock) LockWithData(data []byte) error {
 	return nil
 }
 
-func (l *Lock) lockWithData(data []byte) error {
+func (l *Lock) lockWithData(ctx context.Context, data []byte) error {
 	prefix := fmt.Sprintf("%s/lock-", l.path)
 
 	path := ""
 	var err error
 	for i := 0; i < 3; i++ {
+		if isContextDone(ctx) {
+			return ErrAcquireLockTimeout
+		}
 		path, err = l.c.CreateProtectedEphemeralSequential(prefix, data, l.acl)
 		if err == ErrNoNode {
 			// Create parent node.
@@ -152,10 +171,26 @@ func (l *Lock) lockWithData(data []byte) error {
 			continue
 		}
 
-		ev := <-ch
-		if ev.Err != nil {
-			return ev.Err
+		select {
+		case ev := <-ch:
+			if ev.Err != nil {
+				if err := l.c.Delete(path, -1); err != nil {
+					return err
+				}
+				return ev.Err
+			}
+		case <-ctx.Done():
+			if err := l.c.Delete(path, -1); err != nil {
+				return err
+			}
+			return ErrAcquireLockTimeout
 		}
+	}
+	if isContextDone(ctx) {
+		if err := l.c.Delete(path, -1); err != nil {
+			return err
+		}
+		return ErrAcquireLockTimeout
 	}
 
 	l.seq = seq
@@ -180,4 +215,13 @@ func (l *Lock) Unlock() error {
 	l.seq = 0
 	atomic.StoreInt32(&l.state, lockStateNone)
 	return nil
+}
+
+func isContextDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Support context parameters when acquiring a lock.

We want to cancel or receive timeout error when trying to acquire a lock.  

So i added context is done or not for each step.

I think it would be better if `zk.Conn`'s functions are based on context such as `Create(ctx context.Context, ...)`.