### PR TITLE
conn.Multi takes a specific interface instead of interface{}

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -140,6 +140,11 @@ type statResponse struct {
 //
 
 type CheckVersionRequest PathVersionRequest
+
+func (r CheckVersionRequest) opCode() int32 {
+	return opCheck
+}
+
 type closeRequest struct{}
 type closeResponse struct{}
 
@@ -158,6 +163,10 @@ type connectResponse struct {
 	Passwd          []byte
 }
 
+type operation interface {
+	opCode() int32
+}
+
 type CreateRequest struct {
 	Path  string
 	Data  []byte
@@ -165,7 +174,15 @@ type CreateRequest struct {
 	Flags int32
 }
 
+func (r CreateRequest) opCode() int32 {
+	return opCreate
+}
+
 type CreateContainerRequest CreateRequest
+
+func (r CreateContainerRequest) opCode() int32 {
+	return opCreate
+}
 
 type CreateTTLRequest struct {
 	Path  string
@@ -175,8 +192,17 @@ type CreateTTLRequest struct {
 	Ttl   int64 // ms
 }
 
+func (r CreateTTLRequest) opCode() int32 {
+	return opCreate
+}
+
 type createResponse pathResponse
 type DeleteRequest PathVersionRequest
+
+func (r DeleteRequest) opCode() int32 {
+	return opDelete
+}
+
 type deleteResponse struct{}
 
 type errorResponse struct {
@@ -237,6 +263,10 @@ type SetDataRequest struct {
 	Path    string
 	Data    []byte
 	Version int32
+}
+
+func (r SetDataRequest) opCode() int32 {
+	return opSetData
 }
 
 type setDataResponse statResponse

--- a/zk_test.go
+++ b/zk_test.go
@@ -380,7 +380,7 @@ func TestMulti(t *testing.T) {
 	if err := zk.Delete(path, -1); err != nil && err != ErrNoNode {
 		t.Fatalf("Delete returned error: %+v", err)
 	}
-	ops := []interface{}{
+	ops := []operation{
 		&CreateRequest{Path: path, Data: []byte{1, 2, 3, 4}, Acl: WorldACL(PermAll)},
 		&SetDataRequest{Path: path, Data: []byte{1, 2, 3, 4}, Version: -1},
 	}
@@ -478,7 +478,7 @@ func TestMultiFailures(t *testing.T) {
 		t.Fatalf("Create returned error: %+v", err)
 	}
 
-	ops := []interface{}{
+	ops := []operation{
 		&CreateRequest{Path: firstPath, Data: []byte{1, 2}, Acl: WorldACL(PermAll)},
 		&CreateRequest{Path: secondPath, Data: []byte{3, 4}, Acl: WorldACL(PermAll)},
 	}


### PR DESCRIPTION
Hi, I try to make a pull according to the suggestion from issue https://github.com/go-zookeeper/zk/issues/3, and try to fix it.

Thanks for reviewing it, best wishes.