### PR TITLE
srvr command adapt zookeeper 3.7.0 version

### DIFF
--- a/flw.go
+++ b/flw.go
@@ -23,7 +23,7 @@ import (
 func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 	// different parts of the regular expression that are required to parse the srvr output
 	const (
-		zrVer   = `^Zookeeper version: ([A-Za-z0-9\.\-]+), built on (\d\d/\d\d/\d\d\d\d \d\d:\d\d [A-Za-z0-9:\+\-]+)`
+		zrVer   = `^Zookeeper version: ([A-Za-z0-9\.\-]+), built on ((\d\d/\d\d/\d\d\d\d|\d\d\d\d-\d\d-\d\d) \d\d:\d\d [A-Za-z0-9:\+\-]+)`
 		zrLat   = `^Latency min/avg/max: (\d+)/([0-9.]+)/(\d+)`
 		zrNet   = `^Received: (\d+).*\n^Sent: (\d+).*\n^Connections: (\d+).*\n^Outstanding: (\d+)`
 		zrState = `^Zxid: (0x[A-Za-z0-9]+).*\n^Mode: (\w+).*\n^Node count: (\d+)`
@@ -61,7 +61,7 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 
 		// determine current server
 		var srvrMode Mode
-		switch match[10] {
+		switch match[11] {
 		case "leader":
 			srvrMode = ModeLeader
 		case "follower":
@@ -75,12 +75,16 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 		buildTime, err := time.Parse("01/02/2006 15:04 MST", match[1])
 
 		if err != nil {
-			ss[i] = &ServerStats{Server: servers[i], Error: err}
-			imOk = false
-			continue
+			// compat zookeeper 3.7.0 later
+			buildTime, err = time.Parse("2006-01-02 15:04 MST", match[1])
+			if err != nil {
+				ss[i] = &ServerStats{Server: servers[i], Error: err}
+				imOk = false
+				continue
+			}
 		}
 
-		parsedInt, err := strconv.ParseInt(match[9], 0, 64)
+		parsedInt, err := strconv.ParseInt(match[10], 0, 64)
 
 		if err != nil {
 			ss[i] = &ServerStats{Server: servers[i], Error: err}
@@ -96,14 +100,14 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 
 		// within the regex above, these values must be numerical
 		// so we can avoid useless checking of the error return value
-		minLatency, _ := strconv.ParseInt(match[2], 0, 64)
-		avgLatency, _ := strconv.ParseFloat(match[3], 64)
-		maxLatency, _ := strconv.ParseInt(match[4], 0, 64)
-		recv, _ := strconv.ParseInt(match[5], 0, 64)
-		sent, _ := strconv.ParseInt(match[6], 0, 64)
-		cons, _ := strconv.ParseInt(match[7], 0, 64)
-		outs, _ := strconv.ParseInt(match[8], 0, 64)
-		ncnt, _ := strconv.ParseInt(match[11], 0, 64)
+		minLatency, _ := strconv.ParseInt(match[3], 0, 64)
+		avgLatency, _ := strconv.ParseFloat(match[4], 64)
+		maxLatency, _ := strconv.ParseInt(match[5], 0, 64)
+		recv, _ := strconv.ParseInt(match[6], 0, 64)
+		sent, _ := strconv.ParseInt(match[7], 0, 64)
+		cons, _ := strconv.ParseInt(match[8], 0, 64)
+		outs, _ := strconv.ParseInt(match[9], 0, 64)
+		ncnt, _ := strconv.ParseInt(match[12], 0, 64)
 
 		ss[i] = &ServerStats{
 			Server:      servers[i],


### PR DESCRIPTION
ZooKeeper 3.7.0 change the `srvr` command's output from 
`Zookeeper version: 3.4.6-1569965, built on 02/20/2014 09:09 GMT`
to
`Zookeeper version: 3.7.0-e3704b390a6697bfdf4b0bef79e3da7a4f6bac4b, built on 2021-03-17 09:46 UTC`