### PR TITLE
Add Server var to ServerStats struct

### DIFF
--- a/flw.go
+++ b/flw.go
@@ -106,6 +106,7 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 		ncnt, _ := strconv.ParseInt(match[11], 0, 64)
 
 		ss[i] = &ServerStats{
+			Server:      servers[i],
 			Sent:        sent,
 			Received:    recv,
 			NodeCount:   ncnt,

--- a/structs.go
+++ b/structs.go
@@ -74,6 +74,7 @@ type ServerClients struct {
 
 // ServerStats is the information pulled from the Zookeeper `stat` command.
 type ServerStats struct {
+	Server      string
 	Sent        int64
 	Received    int64
 	NodeCount   int64


### PR DESCRIPTION
Adds `Server` to `ServerStats`. I noticed that for each element part of `ServerStats` you do know which server the data is attached to.

Tested output is below:

```
&{Server:localhost:2181 Sent:2 Received:3 ...} 
```