### PR TITLE
support krb5

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -32,6 +32,7 @@ const (
 	opClose           = -11
 	opSetAuth         = 100
 	opSetWatches      = 101
+	opSetSASL         = 102
 	opError           = -1
 	// Not in protocol, used internally
 	opWatcherEvent = -2
@@ -224,6 +225,7 @@ var (
 		opClose:           "close",
 		opSetAuth:         "setAuth",
 		opSetWatches:      "setWatches",
+		opSetSASL:         "setSASL",
 
 		opWatcherEvent: "watcherEvent",
 	}

--- a/constants.go
+++ b/constants.go
@@ -263,3 +263,23 @@ var (
 		ModeStandalone: "standalone",
 	}
 )
+
+type SASLType uint8
+
+const (
+	NO_SASL SASLType = iota
+	KERBEROS
+)
+
+var (
+	saslTypeNames = map[SASLType]string{
+		KERBEROS: "kerberos",
+	}
+)
+
+func (s SASLType) String() string {
+	if name := saslTypeNames[s]; name != "" {
+		return name
+	}
+	return "none"
+}

--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -13,6 +13,7 @@ import (
 type DNSHostProvider struct {
 	mu         sync.Mutex // Protects everything, so we can add asynchronous updates later.
 	servers    []string
+	hostMap    map[string]string
 	curr       int
 	last       int
 	lookupHost func(string) ([]string, error) // Override of net.LookupHost, for testing.
@@ -31,6 +32,7 @@ func (hp *DNSHostProvider) Init(servers []string) error {
 	}
 
 	found := []string{}
+	hostMap := map[string]string{}
 	for _, server := range servers {
 		host, port, err := net.SplitHostPort(server)
 		if err != nil {
@@ -42,6 +44,7 @@ func (hp *DNSHostProvider) Init(servers []string) error {
 		}
 		for _, addr := range addrs {
 			found = append(found, net.JoinHostPort(addr, port))
+			hostMap[addr] = server
 		}
 	}
 
@@ -53,6 +56,7 @@ func (hp *DNSHostProvider) Init(servers []string) error {
 	stringShuffle(found)
 
 	hp.servers = found
+	hp.hostMap = hostMap
 	hp.curr = -1
 	hp.last = -1
 
@@ -69,7 +73,7 @@ func (hp *DNSHostProvider) Len() int {
 // Next returns the next server to connect to. retryStart will be true
 // if we've looped through all known servers without Connected() being
 // called.
-func (hp *DNSHostProvider) Next() (server string, retryStart bool) {
+func (hp *DNSHostProvider) Next() (server, hostname string, retryStart bool) {
 	hp.mu.Lock()
 	defer hp.mu.Unlock()
 	hp.curr = (hp.curr + 1) % len(hp.servers)
@@ -77,7 +81,7 @@ func (hp *DNSHostProvider) Next() (server string, retryStart bool) {
 	if hp.last == -1 {
 		hp.last = 0
 	}
-	return hp.servers[hp.curr], retryStart
+	return hp.servers[hp.curr], hp.hostMap[hp.servers[hp.curr]], retryStart
 }
 
 // Connected notifies the HostProvider of a successful connection.

--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -44,7 +44,7 @@ func (hp *DNSHostProvider) Init(servers []string) error {
 		}
 		for _, addr := range addrs {
 			found = append(found, net.JoinHostPort(addr, port))
-			hostMap[addr] = server
+			hostMap[net.JoinHostPort(addr, port)] = server
 		}
 	}
 

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -71,12 +71,14 @@ func newLocalHostPortsFacade(inner HostProvider, ports []int) *localHostPortsFac
 func (lhpf *localHostPortsFacade) Len() int                    { return lhpf.inner.Len() }
 func (lhpf *localHostPortsFacade) Connected()                  { lhpf.inner.Connected() }
 func (lhpf *localHostPortsFacade) Init(servers []string) error { return lhpf.inner.Init(servers) }
-func (lhpf *localHostPortsFacade) Next() (string, bool) {
-	server, retryStart := lhpf.inner.Next()
+func (lhpf *localHostPortsFacade) Next() (string, string, bool) {
+	server, hostname, retryStart := lhpf.inner.Next()
+
+	fmt.Println("hostname, ", hostname)
 
 	// If we've already set up a mapping for that server, just return it.
 	if localMapping := lhpf.mapped[server]; localMapping != "" {
-		return localMapping, retryStart
+		return localMapping, hostname, retryStart
 	}
 
 	if lhpf.nextPort == len(lhpf.ports) {
@@ -86,7 +88,7 @@ func (lhpf *localHostPortsFacade) Next() (string, bool) {
 	localMapping := fmt.Sprintf("localhost:%d", lhpf.ports[lhpf.nextPort])
 	lhpf.mapped[server] = localMapping
 	lhpf.nextPort++
-	return localMapping, retryStart
+	return localMapping, hostname, retryStart
 }
 
 var _ HostProvider = &localHostPortsFacade{}
@@ -213,7 +215,7 @@ func TestDNSHostProviderRetryStart(t *testing.T) {
 	}
 
 	for i, td := range testdata {
-		_, retryStartGot := hp.Next()
+		_, _, retryStartGot := hp.Next()
 		if retryStartGot != td.retryStartWant {
 			t.Errorf("%d: retryStart=%v; want %v", i, retryStartGot, td.retryStartWant)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.13
 
 require (
 	github.com/jcmturner/gofork v1.0.0
-	github.com/jcmturner/gokrb5 v8.4.2+incompatible
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/go-zookeeper/zk
 
 go 1.13
+
+require (
+	github.com/jcmturner/gofork v1.0.0
+	github.com/jcmturner/gokrb5 v8.4.2+incompatible
+	github.com/jcmturner/gokrb5/v8 v8.4.2
+)

--- a/sasl.go
+++ b/sasl.go
@@ -222,7 +222,7 @@ func (k *KerberosAuth) writePackage(c *Conn, payload []byte) error {
 	var buffer = make([]byte, sz)
 
 	header := &requestHeader{c.nextXid(), opSetSASL}
-	headerSize, err := encodePacket(buffer, header)
+	headerSize, err := encodePacket(buffer[4:], header)
 	if err != nil {
 		return fmt.Errorf("failed to decode header, err: %s", err)
 	}

--- a/sasl.go
+++ b/sasl.go
@@ -1,0 +1,215 @@
+package zk
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	krb5client "github.com/jcmturner/gokrb5/v8/client"
+	krb5config "github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+	"github.com/jcmturner/gokrb5/v8/iana/chksumtype"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
+	krb5keytab "github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+type SASLConfig struct {
+	SASLType       SASLType
+	KerberosConfig *KerberosConfig
+}
+
+type KerberosConfig struct {
+	KeytabPath  string // keytab file path
+	KrbCfgPath  string // krb5 config file path
+	Username    string
+	Password    string
+	Realm       string
+	ServiceName string
+}
+
+const (
+	TOK_ID_KRB_AP_REQ  = 256
+	GSSAPI_GENERIC_TAG = 0x60
+	GSSAPI_INITIAL     = 1
+	GSSAPI_VERIFY      = 2
+	GSSAPI_FINISH      = 3
+)
+
+type KerberosAuth struct {
+	Config *KerberosConfig
+	ticket messages.Ticket  // client to service ticket
+	encKey types.EncryptionKey // service session key
+	step   int
+}
+
+// newKerberosClient creates kerberos client used to obtain TGT and TGS tokens.
+// It uses pure go Kerberos 5 solution (RFC-4121 and RFC-4120).
+// uses gokrb5 library underlying which is a pure go kerberos client with some GSS-API capabilities.
+func newKerberosClient(c *KerberosConfig) (*krb5client.Client, error) {
+	if c == nil {
+		return nil, fmt.Errorf("kerberos config is nil")
+	}
+	if krb5cfg, err := krb5config.Load(c.KrbCfgPath); err != nil {
+		return nil, err
+	} else {
+		if c.KeytabPath != "" {
+			if keytab, err := krb5keytab.Load(c.KeytabPath); err != nil {
+				return nil, err
+			} else {
+				return krb5client.NewWithKeytab(c.Username, c.Realm, keytab, krb5cfg), nil
+			}
+		} else {
+			return krb5client.NewWithPassword(c.Username, c.Realm, c.Password, krb5cfg), nil
+		}
+	}
+}
+
+func (k *KerberosAuth) newAuthenticatorChecksum() []byte {
+	a := make([]byte, 24)
+	flags := []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}
+	binary.LittleEndian.PutUint32(a[:4], 16)
+	for _, i := range flags {
+		f := binary.LittleEndian.Uint32(a[20:24])
+		f |= uint32(i)
+		binary.LittleEndian.PutUint32(a[20:24], f)
+	}
+	return a
+}
+
+/*
+*
+* Construct Kerberos AP_REQ package, conforming to RFC-4120
+* https://tools.ietf.org/html/rfc4120#page-84
+*
+ */
+func (k *KerberosAuth) createKrb5Token(
+	domain string, cname types.PrincipalName,
+	ticket messages.Ticket, encKey types.EncryptionKey) ([]byte, error) {
+	auth, err := types.NewAuthenticator(domain, cname)
+	if err != nil {
+		return nil, err
+	}
+	auth.Cksum = types.Checksum{
+		CksumType: chksumtype.GSSAPI,
+		Checksum:  k.newAuthenticatorChecksum(),
+	}
+	if APReq, err := messages.NewAPReq(ticket, encKey, auth); err != nil {
+		return nil, err
+	} else {
+		aprBytes := make([]byte, 2)
+		binary.BigEndian.PutUint16(aprBytes, TOK_ID_KRB_AP_REQ)
+		tb, err := APReq.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		aprBytes = append(aprBytes, tb...)
+		return aprBytes, nil
+	}
+
+}
+
+/*
+*
+* Append the GSS-API header to the payload, conforming to RFC-2743
+* Section 3.1, Mechanism-Independent Token Format
+*
+* https://tools.ietf.org/html/rfc2743#page-81
+*
+* GSSAPIHeader + <specific mechanism payload>
+*
+ */
+func (k *KerberosAuth) appendGSSAPIHeader(payload []byte) ([]byte, error) {
+	oidBytes, err := asn1.Marshal(gssapi.OIDKRB5.OID())
+	if err != nil {
+		return nil, err
+	}
+	tkoLengthBytes := asn1tools.MarshalLengthBytes(len(oidBytes) + len(payload))
+	gssapiHeader := append([]byte{GSSAPI_GENERIC_TAG}, tkoLengthBytes...)
+	gssapiHeader = append(gssapiHeader, oidBytes...)
+	GSSPackage := append(gssapiHeader, payload...)
+	return GSSPackage, nil
+}
+
+func (k *KerberosAuth) initSecContext(bytes []byte, krbCli *krb5client.Client) ([]byte, error) {
+	switch k.step {
+	case GSSAPI_INITIAL:
+		krb5Token, err := k.createKrb5Token(
+			krbCli.Credentials.Domain(),
+			krbCli.Credentials.CName(),
+			k.ticket, k.encKey)
+		if err != nil {
+			return nil, err
+		}
+		k.step = GSSAPI_VERIFY
+		return k.appendGSSAPIHeader(krb5Token)
+	case GSSAPI_VERIFY:
+		wrapTokenReq := gssapi.WrapToken{}
+		if err := wrapTokenReq.Unmarshal(bytes, true); err != nil {
+			return nil, err
+		}
+		// Validate response.
+		isValid, err := wrapTokenReq.Verify(k.encKey, keyusage.GSSAPI_ACCEPTOR_SEAL)
+		if !isValid {
+			return nil, err
+		}
+
+		wrapTokenResponse, err := gssapi.NewInitiatorWrapToken(wrapTokenReq.Payload, k.encKey)
+		if err != nil {
+			return nil, err
+		}
+		k.step = GSSAPI_FINISH
+		return wrapTokenResponse.Marshal()
+	}
+	return nil, nil
+}
+
+/* This does the handshake for authorization */
+func (k *KerberosAuth) Authorize(zkConn *Conn) error {
+	// create kerberos client
+	krbCli, err := newKerberosClient(zkConn.saslConfig.KerberosConfig)
+	if err != nil {
+		return fmt.Errorf("fail to create kerberos client, err: %s", err)
+	}
+	// kerberos client login for TGT token
+	if err = krbCli.Login(); err != nil {
+		return fmt.Errorf("kerberos client fail to login, err: %s", err)
+	}
+
+	// construct SPN using serviceName and host, format: zookeeper/host
+	spn := fmt.Sprintf("%s/%s", k.Config.ServiceName, strings.SplitN(zkConn.hostname, ":", 2)[0])
+
+	// kerberos client obtain TGS token
+	if k.ticket, k.encKey, err = krbCli.GetServiceTicket(spn); err != nil {
+		return fmt.Errorf("kerberos client fail to get service ticket, err: %s", err)
+	}
+	k.step = GSSAPI_INITIAL
+	var recvBytes []byte = nil
+	var packBytes []byte = nil
+	defer krbCli.Destroy()
+	for {
+		if packBytes, err = k.initSecContext(recvBytes, krbCli); err != nil {
+			return fmt.Errorf("failed to init session context while performing kerberos authentication, err: %s", err)
+		}
+		var res = &setSaslResponse{}
+		if _, err = zkConn.sendRequest(opSetAuth, &getSaslRequest{packBytes}, res, nil); err != nil {
+			return fmt.Errorf("failed to handshake with kerberos, err: %s", err)
+		}
+		if k.step == GSSAPI_VERIFY {
+			recvBytes = []byte(res.Token)
+		} else if k.step == GSSAPI_FINISH {
+			return nil
+		}
+	}
+}
+
+func writePackage(zkConn *Conn, payload []byte) error {
+
+} 
+
+func readPackage(zkConn *Conn) ([]byte, error) {
+	
+}


### PR DESCRIPTION
add sasl/kerberos auth in func `authenticate`

## Usage:

```golang
package main

import (
	"fmt"
	"time"

	"github.com/go-zookeeper/zk"
)

func main() {

	zkConn, _, err := zk.Connect([]string{"localhost"}, time.Second*10, zk.WithSASLConfig(
		&zk.SASLConfig{
			SASLType: zk.KERBEROS,
			KerberosConfig: &zk.KerberosConfig{
				KeytabPath:  "./test.keytab",
				KrbCfgPath:  "./test.config",
				Realm:       "test.com",
				Username:    "test",
				ServiceName: "zookeeper",
			},
		},
	))
	if err != nil {
		panic(err)
	}
	if res, _, err := zkConn.Get("/test/test_krb5"); err != nil {
		fmt.Println("get %v from zookeeper", res)
	} else {
		panic(err)
	}
}

```