### PR TITLE
Fix deadlock caused by non-responsive ZK servers

### DIFF
--- a/tcp_server_test.go
+++ b/tcp_server_test.go
@@ -1,0 +1,39 @@
+package zk
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+)
+
+func WithListenServer(t *testing.T, test func(server string)) {
+	startPort := int(rand.Int31n(6000) + 10000)
+	server := fmt.Sprintf("localhost:%d", startPort)
+	l, err := net.Listen("tcp", server)
+	if err != nil {
+		t.Fatalf("Failed to start listen server: %v", err)
+	}
+	defer l.Close()
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				fmt.Println("Failed to accept connection: ", err.Error())
+				continue
+			}
+
+			handleRequest(conn)
+		}
+	}()
+
+	test(server)
+}
+
+// Handles incoming requests.
+func handleRequest(conn net.Conn) {
+	time.Sleep(5 * time.Second)
+	conn.Close()
+}

--- a/tcp_server_test.go
+++ b/tcp_server_test.go
@@ -18,15 +18,12 @@ func WithListenServer(t *testing.T, test func(server string)) {
 	defer l.Close()
 
 	go func() {
-		for {
-			conn, err := l.Accept()
-			if err != nil {
-				fmt.Println("Failed to accept connection: ", err.Error())
-				continue
-			}
-
-			handleRequest(conn)
+		conn, err := l.Accept()
+		if err != nil {
+			t.Logf("Failed to accept connection: %s", err.Error())
 		}
+
+		handleRequest(conn)
 	}()
 
 	test(server)


### PR DESCRIPTION
Fixes https://github.com/go-zookeeper/zk/issues/79

Instead of blindly waiting for a response from `queueRequest`, wait for a message on either the requests response channel or an indication that the client `shouldQuit`. This ensures that any ongoing requests are completed when a client is closed. 