### PR TITLE
bugfix: invalidate current watchers if connections is being reset

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -374,12 +374,14 @@ func (c *Conn) connect() error {
 
 		if retryStart {
 			c.flushUnsentRequests(ErrNoServer)
+			c.invalidateWatches(ErrNoServer)
 			select {
 			case <-time.After(time.Second):
 				// pass
 			case <-c.shouldQuit:
 				c.setState(StateDisconnected)
 				c.flushUnsentRequests(ErrClosing)
+				c.invalidateWatches(ErrClosing)
 				return ErrClosing
 			}
 		}


### PR DESCRIPTION
When client becomes isolated it would be great if the business logic layer could be aware of the partitioning if it relies on watches to update its state.

This fixes https://github.com/go-zookeeper/zk/issues/83