### PR TITLE
Backport Addwatch from inf-rno/zk fork

### DIFF
--- a/_examples/basic.go
+++ b/_examples/basic.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/inf-rno/zk"
 )
 
 func main() {
-	c, _, err := zk.Connect([]string{"127.0.0.1"}, time.Second) //*10)
+	c, _, err := zk.Connect([]string{"127.0.0.1:2181", "127.0.0.1:2182", "127.0.0.1:2183"}, time.Second) //*10)
 	if err != nil {
 		panic(err)
 	}
-	children, stat, ch, err := c.ChildrenW("/")
+	ch, err := c.AddWatch("/", true)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("%+v %+v\n", children, stat)
-	e := <-ch
-	fmt.Printf("%+v\n", e)
+	for e := range ch {
+		fmt.Printf("%+v\n", e)
+	}
 }

--- a/constants.go
+++ b/constants.go
@@ -32,6 +32,8 @@ const (
 	opClose           = -11
 	opSetAuth         = 100
 	opSetWatches      = 101
+	opSetWatches2     = 105
+	opAddWatch        = 106
 	opError           = -1
 	// Not in protocol, used internally
 	opWatcherEvent = -2
@@ -101,6 +103,28 @@ type State int32
 // String converts State to a readable string.
 func (s State) String() string {
 	if name := stateNames[s]; name != "" {
+		return name
+	}
+	return "Unknown"
+}
+
+const (
+	WatchModePersistent          AddWatchMode = 0
+	WatchModePersistentRecursive AddWatchMode = 1
+)
+
+var (
+	addWatchModeNames = map[AddWatchMode]string{
+		WatchModePersistent:          "WatchModePersistent",
+		WatchModePersistentRecursive: "WatchModePersistentRecursive",
+	}
+)
+
+// AddWatchMode defines the mode used to create a persistent watch
+type AddWatchMode int32
+
+func (m AddWatchMode) String() string {
+	if name := addWatchModeNames[m]; name != "" {
 		return name
 	}
 	return "Unknown"
@@ -224,6 +248,8 @@ var (
 		opClose:           "close",
 		opSetAuth:         "setAuth",
 		opSetWatches:      "setWatches",
+		opSetWatches2:     "setWatches2",
+		opAddWatch:        "addWatch",
 
 		opWatcherEvent: "watcherEvent",
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-zookeeper/zk
+module github.com/inf-rno/zk
 
 go 1.13

--- a/structs.go
+++ b/structs.go
@@ -234,6 +234,13 @@ type setAclRequest struct {
 
 type setAclResponse statResponse
 
+type addWatchRequest struct {
+	Path string
+	Mode AddWatchMode
+}
+
+type addWatchResponse struct{}
+
 type SetDataRequest struct {
 	Path    string
 	Data    []byte
@@ -263,6 +270,17 @@ type setWatchesRequest struct {
 }
 
 type setWatchesResponse struct{}
+
+type setWatches2Request struct {
+	RelativeZxid               int64
+	DataWatches                []string
+	ExistWatches               []string
+	ChildWatches               []string
+	PersistentWatches          []string
+	PersistentRecursiveWatches []string
+}
+
+type setWatches2Response struct{}
 
 type syncRequest pathRequest
 type syncResponse pathResponse
@@ -624,6 +642,10 @@ func requestStructForOp(op int32) interface{} {
 		return &SetDataRequest{}
 	case opSetWatches:
 		return &setWatchesRequest{}
+	case opSetWatches2:
+		return &setWatches2Request{}
+	case opAddWatch:
+		return &addWatchRequest{}
 	case opSync:
 		return &syncRequest{}
 	case opSetAuth:

--- a/zk_test.go
+++ b/zk_test.go
@@ -743,7 +743,7 @@ func TestSetWatchers(t *testing.T) {
 	zk.reconnectLatch = make(chan struct{})
 	zk.setWatchLimit = 1024 // break up set-watch step into 1k requests
 	var setWatchReqs atomic.Value
-	zk.setWatchCallback = func(reqs []*setWatchesRequest) {
+	zk.setWatchCallback = func(reqs []*setWatches2Request) {
 		setWatchReqs.Store(reqs)
 	}
 


### PR DESCRIPTION
This backports the `AddWatch` function from https://github.com/inf-rno/zk/pull/1

> Add persistent, recursive watch functionality introduced in 3.6.0
> Upgrade setWatches to setWatches2

Cc @inf-rno