### PR TITLE
Remove redundant srvs shuffle

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -185,9 +185,6 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 
 	srvs := FormatServers(servers)
 
-	// Randomize the order of the servers to avoid creating hotspots
-	stringShuffle(srvs)
-
 	ec := make(chan Event, eventChanSize)
 	conn := &Conn{
 		dialer:         net.DialTimeout,


### PR DESCRIPTION
We have servers shuffle in `github.com/samuel/go-zookeeper/conn.go:191` and `github.com/samuel/go-zookeeper/dnshostprovider.go:53`, so one of them should be removed. The shuffle logic is more proper to keep inside the real connect component, that's why I choose to remove the outside one.