### PR TITLE
 Enhance HostProvider to update host provider on retryStart occurrence

### DIFF
--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -86,3 +86,9 @@ func (hp *DNSHostProvider) Connected() {
 	defer hp.mu.Unlock()
 	hp.last = hp.curr
 }
+
+// UpdateServerList is called when HostProvider is abnormal.
+// Update the list of servers.
+func (hp *DNSHostProvider) UpdateServerList(servers []string) error {
+	return hp.Init(servers)
+}

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -71,6 +71,9 @@ func newLocalHostPortsFacade(inner HostProvider, ports []int) *localHostPortsFac
 func (lhpf *localHostPortsFacade) Len() int                    { return lhpf.inner.Len() }
 func (lhpf *localHostPortsFacade) Connected()                  { lhpf.inner.Connected() }
 func (lhpf *localHostPortsFacade) Init(servers []string) error { return lhpf.inner.Init(servers) }
+func (lhpf *localHostPortsFacade) UpdateServerList(servers []string) error {
+	return lhpf.inner.UpdateServerList(servers)
+}
 func (lhpf *localHostPortsFacade) Next() (string, bool) {
 	server, retryStart := lhpf.inner.Next()
 


### PR DESCRIPTION
This pull request aims to enhance the functionality of the **HostProvider** by adding the **hostProvider.UpdateServerList** function. The goal is to update the host provider when the retryStart condition occurs twice.

During runtime, when the client is connecting to the ZooKeeper server, it is crucial to handle scenarios where the server undergoes a service restart. In such cases, the IP addresses of the ZooKeeper server may change, rendering the previously resolved IP addresses invalid. Currently, the client only selects an IP address from the initial resolution and does not perform subsequent DNS resolutions. As a result, the client continuously attempts to connect to an invalid IP.

In my specific case, we have a ZooKeeper deployment based on Kubernetes using a headless service. Consequently, when ZooKeeper restarts, the IP addresses can change, leading to connection issues.

By introducing the **[hostProvider.UpdateServerList](https://github.com/ChenHaoHu/zk/blob/master/conn.go#L170)** function, we ensure that the host provider is updated when the retryStart condition occurs twice. This enables the client to handle changes in the ZooKeeper server's IP addresses effectively and avoid attempting connections to invalid IPs.

Overall, this enhancement addresses the issue of connection failures due to ZooKeeper service restarts and provides a more robust and reliable connection mechanism. The UpdateServerList function in the DNSHostProvider plays a vital role in re-resolving the previously configured domain name information, ensuring accurate and up-to-date IP address resolutions.

Your feedback and suggestions are greatly appreciated. 

Thank you for your time and consideration.

Best regards,
ChenHaoHu