### PR TITLE
break out tests that run a java zk cluster 

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Setup Java 14
         uses: actions/setup-java@v3
         with:
+          distribution: 'oracle'
           java-version: 14
 
       - name: Checkout code

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
             go-version: ${{ matrix.go-version }} 
 
       - name: Setup Java 14
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 14
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,32 @@
+name: integration_test
+on: [push, pull_request]
+
+jobs:
+  integration_test:
+    name: integration_test
+    strategy:
+      matrix:
+        zk-version: [3.5.8, 3.6.1]
+        go-version: [1.13.x, 1.14.x]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Go ${{ matrix.go }} setup
+        uses: actions/setup-go@v1
+        with:
+            go-version: ${{ matrix.go-version }} 
+
+      - name: Setup Java 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Test code
+        run: make test ZK_VERSION=${{ matrix.zk-version }}
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./profile.cov

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
             go-version: ${{ matrix.go-version }} 
 
       - name: Setup Java 14
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v1
         with:
           java-version: 14
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java 14
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: 14
 
       - name: Checkout code

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java 14
         uses: actions/setup-java@v3
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: 14
 
       - name: Checkout code

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,21 +7,21 @@ jobs:
     strategy:
       matrix:
         zk-version: [3.5.8, 3.6.1]
-        go-version: [1.13.x, 1.14.x]
+        go-version: ['oldstable', 'stable']
     runs-on: ubuntu-latest
     steps:
       - name: Go ${{ matrix.go }} setup
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
             go-version: ${{ matrix.go-version }} 
 
       - name: Setup Java 14
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 14
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Test code
         run: make test ZK_VERSION=${{ matrix.zk-version }}

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -6,7 +6,7 @@ jobs:
     name: unittest
     strategy:
       matrix:
-        go-version: ['1.13.x', '1.14.x', 'stable']
+        go-version: ['oldstable', 'stable']
     runs-on: ubuntu-latest
     steps:
       - name: Go ${{ matrix.go }} setup
@@ -15,7 +15,7 @@ jobs:
             go-version: ${{ matrix.go-version }} 
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Run unittest ${{ matrix.go }}
         run: make unittest 

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -6,27 +6,16 @@ jobs:
     name: unittest
     strategy:
       matrix:
-        zk-version: [3.5.8, 3.6.1]
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.13.x, 1.14.x, stable]
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
+      - name: Go ${{ matrix.go }} setup
         uses: actions/setup-go@v1
         with:
             go-version: ${{ matrix.go-version }} 
 
-      - name: Setup Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 14
-
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Test code
-        run: make test ZK_VERSION=${{ matrix.zk-version }}
-
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./profile.cov
+      - name: Run unittest ${{ matrix.go }}
+        run: make unittest 

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -6,11 +6,11 @@ jobs:
     name: unittest
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, stable]
+        go-version: ['1.13.x', '1.14.x', 'stable']
     runs-on: ubuntu-latest
     steps:
       - name: Go ${{ matrix.go }} setup
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
             go-version: ${{ matrix.go-version }} 
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ lint:
 build:
 	go build ./...
 
+.PHONY: unittest
+unittest:
+	go test -timeout 500s -v -race -covermode atomic -skip=Integration ./...
+
 .PHONY: test
 test: build zookeeper
 	go test -timeout 500s -v -race -covermode atomic -coverprofile=profile.cov $(PACKAGES)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -16,7 +16,7 @@ func (lw logWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func TestBasicCluster(t *testing.T) {
+func TestIntegration_BasicCluster(t *testing.T) {
 	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +51,7 @@ func TestBasicCluster(t *testing.T) {
 }
 
 // If the current leader dies, then the session is reestablished with the new one.
-func TestClientClusterFailover(t *testing.T) {
+func TestIntegration_ClientClusterFailover(t *testing.T) {
 	tc, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func TestClientClusterFailover(t *testing.T) {
 
 // If a ZooKeeper cluster looses quorum then a session is reconnected as soon
 // as the quorum is restored.
-func TestNoQuorum(t *testing.T) {
+func TestIntegration_NoQuorum(t *testing.T) {
 	tc, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -189,7 +189,7 @@ func TestNoQuorum(t *testing.T) {
 	}
 }
 
-func TestWaitForClose(t *testing.T) {
+func TestIntegration_WaitForClose(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -225,7 +225,7 @@ CONNECTED:
 	}
 }
 
-func TestBadSession(t *testing.T) {
+func TestIntegration_BadSession(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func TestRecurringReAuthHang(t *testing.T) {
+func TestIntegration_RecurringReAuthHang(t *testing.T) {
 	zkC, err := StartTestCluster(t, 3, ioutil.Discard, ioutil.Discard)
 	if err != nil {
 		panic(err)

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -15,7 +15,7 @@ func localhostLookupHost(host string) ([]string, error) {
 
 // TestDNSHostProviderCreate is just like TestCreate, but with an
 // overridden HostProvider that ignores the provided hostname.
-func TestDNSHostProviderCreate(t *testing.T) {
+func TestIntegration_DNSHostProviderCreate(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -96,7 +96,7 @@ var _ HostProvider = &localHostPortsFacade{}
 // restarts. It wraps the DNSHostProvider in a lightweight facade that
 // remaps addresses to localhost:$PORT combinations corresponding to
 // the test ZooKeeper instances.
-func TestDNSHostProviderReconnect(t *testing.T) {
+func TestIntegration_DNSHostProviderReconnect(t *testing.T) {
 	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)

--- a/lock_test.go
+++ b/lock_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestLock(t *testing.T) {
+func TestIntegration_Lock(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestLock(t *testing.T) {
 
 // This tests creating a lock with a path that's more than 1 node deep (e.g. "/test-multi-level/lock"),
 // when a part of that path already exists (i.e. "/test-multi-level" node already exists).
-func TestMultiLevelLock(t *testing.T) {
+func TestIntegration_MultiLevelLock(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)

--- a/server_help_test.go
+++ b/server_help_test.go
@@ -38,6 +38,8 @@ type TestCluster struct {
 // testing. This should be used on CI systems and local only when needed whereas unit tests should remain
 // fast and not rely on external dependencies.
 func StartTestCluster(t *testing.T, size int, stdout, stderr io.Writer) (*TestCluster, error) {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("ZK cluster tests skipped in short case.")
 	}

--- a/zk_test.go
+++ b/zk_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-func TestStateChanges(t *testing.T) {
+func TestIntegration_StateChanges(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -66,7 +66,7 @@ func TestStateChanges(t *testing.T) {
 	verifyEventOrder(eventChan, []State{StateDisconnected}, "event channel")
 }
 
-func TestCreate(t *testing.T) {
+func TestIntegration_Create(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestCreateTTL(t *testing.T) {
+func TestIntegration_CreateTTL(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -149,7 +149,7 @@ func TestCreateTTL(t *testing.T) {
 	}
 }
 
-func TestCreateContainer(t *testing.T) {
+func TestIntegration_CreateContainer(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func TestCreateContainer(t *testing.T) {
 	}
 }
 
-func TestIncrementalReconfig(t *testing.T) {
+func TestIntegration_IncrementalReconfig(t *testing.T) {
 	if val, ok := os.LookupEnv("zk_version"); ok {
 		if !strings.HasPrefix(val, "3.5") {
 			t.Skip("running with zookeeper that does not support this api")
@@ -281,7 +281,7 @@ func TestIncrementalReconfig(t *testing.T) {
 	}
 }
 
-func TestReconfig(t *testing.T) {
+func TestIntegration_Reconfig(t *testing.T) {
 	if val, ok := os.LookupEnv("zk_version"); ok {
 		if !strings.HasPrefix(val, "3.5") {
 			t.Skip("running with zookeeper that does not support this api")
@@ -332,7 +332,7 @@ func TestReconfig(t *testing.T) {
 	requireNoError(t, err, "failed to reconfig cluster")
 }
 
-func TestOpsAfterCloseDontDeadlock(t *testing.T) {
+func TestIntegration_OpsAfterCloseDontDeadlock(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +363,7 @@ func TestOpsAfterCloseDontDeadlock(t *testing.T) {
 	}
 }
 
-func TestMulti(t *testing.T) {
+func TestIntegration_Multi(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -400,7 +400,7 @@ func TestMulti(t *testing.T) {
 	}
 }
 
-func TestIfAuthdataSurvivesReconnect(t *testing.T) {
+func TestIntegration_IfAuthdataSurvivesReconnect(t *testing.T) {
 	// This test case ensures authentication data is being resubmited after
 	// reconnect.
 	testNode := "/auth-testnode"
@@ -452,7 +452,7 @@ func TestIfAuthdataSurvivesReconnect(t *testing.T) {
 	}
 }
 
-func TestMultiFailures(t *testing.T) {
+func TestIntegration_MultiFailures(t *testing.T) {
 	// This test case ensures that we return the errors associated with each
 	// opeThis in the event a call to Multi() fails.
 	const firstPath = "/gozk-test-first"
@@ -500,7 +500,7 @@ func TestMultiFailures(t *testing.T) {
 	}
 }
 
-func TestGetSetACL(t *testing.T) {
+func TestIntegration_GetSetACL(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -554,7 +554,7 @@ func TestGetSetACL(t *testing.T) {
 	}
 }
 
-func TestAuth(t *testing.T) {
+func TestIntegration_Auth(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -604,7 +604,7 @@ func TestAuth(t *testing.T) {
 	}
 }
 
-func TestChildren(t *testing.T) {
+func TestIntegration_Children(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -657,7 +657,7 @@ func TestChildren(t *testing.T) {
 	}
 }
 
-func TestChildWatch(t *testing.T) {
+func TestIntegration_ChildWatch(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -728,7 +728,7 @@ func TestChildWatch(t *testing.T) {
 	}
 }
 
-func TestSetWatchers(t *testing.T) {
+func TestIntegration_SetWatchers(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -871,7 +871,7 @@ func TestSetWatchers(t *testing.T) {
 	}
 }
 
-func TestExpiringWatch(t *testing.T) {
+func TestIntegration_ExpiringWatch(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -947,7 +947,7 @@ func TestIdempotentClose(t *testing.T) {
 	zk.Close()
 }
 
-func TestSlowServer(t *testing.T) {
+func TestIntegration_SlowServer(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
@@ -1006,7 +1006,7 @@ func TestSlowServer(t *testing.T) {
 	}
 }
 
-func TestMaxBufferSize(t *testing.T) {
+func TestIntegration_MaxBufferSize(t *testing.T) {
 	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The tests that spin up a zookeeper cluster for testing are flaky in nature. They provide a great verification of behavior but are not isolated to Go. 

This leaves the tests in a state where they flake for various reasons outside of the control of the Go runtime. 