### PR TITLE
Added constructor for DNSHostProvider

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -191,7 +191,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 	ec := make(chan Event, eventChanSize)
 	conn := &Conn{
 		dialer:         net.DialTimeout,
-		hostProvider:   &DNSHostProvider{},
+		hostProvider:   NewDNSHostProvider(net.LookupHost),
 		conn:           nil,
 		state:          StateDisconnected,
 		eventChan:      ec,

--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -18,6 +18,13 @@ type DNSHostProvider struct {
 	lookupHost func(string) ([]string, error) // Override of net.LookupHost, for testing.
 }
 
+// NewDNSHostProvider provides a way to set up your own lookup function for hosts.
+func NewDNSHostProvider(lookupHost func(string) ([]string, error)) *DNSHostProvider {
+	return &DNSHostProvider{
+		lookupHost: lookupHost,
+	}
+}
+
 // Init is called first, with the servers specified in the connection
 // string. It uses DNS to look up addresses for each server, then
 // shuffles them all together.

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -24,7 +24,7 @@ func TestIntegration_DNSHostProviderCreate(t *testing.T) {
 
 	port := ts.Servers[0].Port
 	server := fmt.Sprintf("foo.example.com:%d", port)
-	hostProvider := &DNSHostProvider{lookupHost: localhostLookupHost}
+	hostProvider := NewDNSHostProvider(localhostLookupHost)
 	zk, _, err := Connect([]string{server}, time.Second*15, WithHostProvider(hostProvider))
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
@@ -103,9 +103,9 @@ func TestIntegration_DNSHostProviderReconnect(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	innerHp := &DNSHostProvider{lookupHost: func(host string) ([]string, error) {
+	innerHp := NewDNSHostProvider(func(host string) ([]string, error) {
 		return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
-	}}
+	})
 	ports := make([]int, 0, len(ts.Servers))
 	for _, server := range ts.Servers {
 		ports = append(ports, server.Port)
@@ -172,9 +172,9 @@ func TestIntegration_DNSHostProviderReconnect(t *testing.T) {
 func TestDNSHostProviderRetryStart(t *testing.T) {
 	t.Parallel()
 
-	hp := &DNSHostProvider{lookupHost: func(host string) ([]string, error) {
+	hp := NewDNSHostProvider(func(host string) ([]string, error) {
 		return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
-	}}
+	})
 
 	if err := hp.Init([]string{"foo.example.com:12345"}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This pull request aims to add an option to change logic of dns host resolving.

In my scenario, when I scale the K8s cluster down then extra replicas will be deleted, and its dns records will be deleted too. With the given state of affairs, I need to update host list on every pod to evade errors:

1. https://github.com/go-zookeeper/zk/blob/c5e730e9ba62dbf3912923fdad523ed89192fb3b/dnshostprovider.go#L41C5-L41C5
2. https://github.com/go-zookeeper/zk/blob/c5e730e9ba62dbf3912923fdad523ed89192fb3b/conn.go#L216

but I think it's preferable in the situation to ignore a part of those hosts to improve reliability. In other words, I want to pass my own host resolve logic in DNSHostProvider. In my opinion, a constructor is the best way to achieve this.