### PR TITLE
Align flags with the CreateMode registered on zookeeper libs

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -76,9 +76,11 @@ const (
 
 const (
 	// FlagEphemeral means the node is ephemeral.
-	FlagEphemeral = 1
-	FlagSequence  = 2
-	FlagTTL       = 4
+	FlagPersistent = 0
+	FlagEphemeral  = 1
+	FlagSequence   = 2
+	FlagContainer  = 4
+	FlagTTL        = 5
 )
 
 var (


### PR DESCRIPTION
The flags added were not aligned with the flags from [zookeeper repo](https://github.com/apache/zookeeper/blob/d12aba599233b0fcba0b9b945ed3d2f45d4016f0/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java#L64). This change aligns both to support the multiple CreateModes supported by zookeeper.

Refer to https://github.com/go-zookeeper/zk/issues/119