### PR TITLE
tests: use t.TempDir() for tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -33,8 +33,6 @@ func TestIntegration_BasicCluster(t *testing.T) {
 	}
 	defer zk2.Close()
 
-	time.Sleep(time.Second * 5)
-
 	if _, err := zk1.Create("/gozk-test", []byte("foo-cluster"), 0, WorldACL(PermAll)); err != nil {
 		t.Fatalf("Create failed on node 1: %+v", err)
 	}

--- a/server_help_test.go
+++ b/server_help_test.go
@@ -3,7 +3,6 @@ package zk
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -16,10 +15,6 @@ const (
 	_testConfigName   = "zoo.cfg"
 	_testMyIDFileName = "myid"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 type TestServer struct {
 	Port   int
@@ -54,8 +49,7 @@ func StartTestCluster(t *testing.T, size int, stdout, stderr io.Writer) (*TestCl
 		}
 	}
 
-	tmpPath, err := ioutil.TempDir("", "gozk")
-	requireNoError(t, err, "failed to create tmp dir for test server setup")
+	tmpPath := t.TempDir()
 
 	success := false
 	startPort := int(rand.Int31n(6000) + 10000)
@@ -152,7 +146,7 @@ func (tc *TestCluster) Stop() error {
 	for _, srv := range tc.Servers {
 		srv.Srv.Stop()
 	}
-	defer os.RemoveAll(tc.Path)
+
 	return tc.waitForStop(5, time.Second)
 }
 
@@ -254,6 +248,8 @@ func (tc *TestCluster) StopAllServers() error {
 }
 
 func requireNoError(t *testing.T, err error, msgAndArgs ...interface{}) {
+	t.Helper()
+
 	if err != nil {
 		t.Logf("received unexpected error: %v", err)
 		t.Fatal(msgAndArgs...)

--- a/zk_test.go
+++ b/zk_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -187,6 +186,7 @@ func TestIntegration_CreateContainer(t *testing.T) {
 }
 
 func TestIntegration_IncrementalReconfig(t *testing.T) {
+	// todo: semver test harness for version?
 	if val, ok := os.LookupEnv("zk_version"); ok {
 		if !strings.HasPrefix(val, "3.5") {
 			t.Skip("running with zookeeper that does not support this api")
@@ -199,10 +199,7 @@ func TestIntegration_IncrementalReconfig(t *testing.T) {
 	defer ts.Stop()
 
 	// start and add a new server.
-	tmpPath, err := ioutil.TempDir("", "gozk")
-	requireNoError(t, err, "failed to create tmp dir for test server setup")
-	defer os.RemoveAll(tmpPath)
-
+	tmpPath := t.TempDir()
 	startPort := int(rand.Int31n(6000) + 10000)
 
 	srvPath := filepath.Join(tmpPath, fmt.Sprintf("srv4"))


### PR DESCRIPTION
1.15 added https://pkg.go.dev/testing#T.TempDir

includes .gitattributes to ensure eol as LF