### PR TITLE
<fix>[constants]: add StateSyncConnected WatchEvent state

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -65,6 +65,7 @@ const (
 	StateUnknown           State = -1
 	StateDisconnected      State = 0
 	StateConnecting        State = 1
+	StateSyncConnected     State = 3
 	StateAuthFailed        State = 4
 	StateConnectedReadOnly State = 5
 	StateSaslAuthenticated State = 6
@@ -92,6 +93,7 @@ var (
 		StateConnecting:        "StateConnecting",
 		StateConnected:         "StateConnected",
 		StateHasSession:        "StateHasSession",
+		StateSyncConnected:     "StateSyncConnected",
 	}
 )
 


### PR DESCRIPTION
NOTE: WatcherEvent State will change from `StateUnknown` to `StateSyncConnected`

jeffbean: rebased authored commit from @KaithyRookie to pickup unit test configuration in github. 

StateSyncConnected means client is connected to a server in the ensemble