### PR TITLE
Create stale.yml github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,14 +21,15 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-stale: 180
         days-before-issue-stale: 730
-        days-before-close: 15
+        days-before-close: 30
         days-before-pr-close: -1
-        debug-only: 'true'
-        exempt-issue-milestones: "v2"
+        stale-pr-message: 'Stale pull request detected at 180 days. Please update, comment, or rebase.'
+        stale-issue-message: 'This issue is marked as stale. If you want to keep this issue open, please leave a comment, otherwise the issue will be closed due to inactivity.'
+        close-issue-message: "This issue has been closed due to inactivity after being stale for 30 days."
+        debug-only: true
+        exempt-all-milestones: true
         

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 12 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 180
+        days-before-issue-stale: 730
+        days-before-close: 15
+        days-before-pr-close: -1
+        debug-only: 'true'
+        exempt-issue-milestones: "v2"
+        


### PR DESCRIPTION
Github action to post when issues and PRs are stale. To start this has debug-only to see a dry run and adjust from the results.

https://github.com/actions/stale

first draft:
- issues are stale after 2 years, give 15 days before close. 
- PRs are 6 months stale (we want to rebase) and never closes. 
- debug-only (will not post anything)
- Exclude both from the milestone "v2" that we track. 