### PR TITLE
update github actions. cleanup and edits. 

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,7 +2,7 @@ coverage:
   status:
     patch:
       default:
-        target: 75%
+        target: 80%
     project:
       default:
-        threshold: 1%
+        threshold: 76%

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,7 +10,7 @@ jobs:
         go-version: ['oldstable', 'stable']
     runs-on: ubuntu-latest
     steps:
-      - name: Go ${{ matrix.go }} setup
+      - name: Go ${{ matrix.go-version }} setup
         uses: actions/setup-go@v4
         with:
             go-version: ${{ matrix.go-version }} 
@@ -28,6 +28,8 @@ jobs:
         run: make test ZK_VERSION=${{ matrix.zk-version }}
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v1
+        # only upload one result from the matrix. 
+        if: ${{ strategy.job-index == 0 }}
+        uses: codecov/codecov-action@v4
         with:
           file: ./profile.cov

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,6 +1,12 @@
 name: integration_test
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    
 jobs:
   integration_test:
     name: integration_test

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
     - master
-    
+
 jobs:
   integration_test:
     name: integration_test
@@ -38,4 +38,5 @@ jobs:
         if: ${{ strategy.job-index == 0 }}
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           file: ./profile.cov

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,7 @@
 
 name: lint
 on: [pull_request]
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'no-issue-activity'

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,6 +1,12 @@
 name: unittest
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    
 jobs:
   unittest:
     name: unittest

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -9,7 +9,7 @@ jobs:
         go-version: ['oldstable', 'stable']
     runs-on: ubuntu-latest
     steps:
-      - name: Go ${{ matrix.go }} setup
+      - name: Go ${{ matrix.go-version }} setup
         uses: actions/setup-go@v4
         with:
             go-version: ${{ matrix.go-version }} 
@@ -17,5 +17,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Run unittest ${{ matrix.go }}
+      - name: Run unittest ${{ matrix.go-version }}
         run: make unittest 


### PR DESCRIPTION

1. action/stale: debug mode shows deprecation warning of older version. update to v9 (current latest)
2. integration_test and unittest workflows: update tiggers to prevent double trigger on PR update. 
3. action/codecov: update version, and settings for action.
4. action/codecov: if condition on the test matrix to only run on the first matric job, removing the upload to happen for each combo in the test matrix. 
5. codecov.yaml: update threshold to what we have now at 76%. also up the patch to 80%.