### PR TITLE
adding requireMinimumZkVersion test helper

### DIFF
--- a/zk_test.go
+++ b/zk_test.go
@@ -1205,6 +1205,9 @@ func requireMinimumZkVersion(t *testing.T, minimum string) {
 
 	minimumV, actualV := parseFn(minimum), parseFn(actualVersionStr)
 	for i, p := range minimumV {
+		if len(actualV) <= i {
+			break
+		}
 		if actualV[i] < p {
 			t.Skipf("zookeeper required min version not met; requires: %q, actual: %q", minimum, actualVersionStr)
 		}


### PR DESCRIPTION
inspiration from https://github.com/go-zookeeper/zk/pull/88

cleanup up the logic. but the idea is to support the tests requiring a version of ZK based on the API support in ZK.