### PR TITLE
[BC] CreateMode: refactor and fix FlagX Create flags. 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1064,6 +1064,10 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 		return "", err
 	}
 
+	if createMode.isTTL {
+		return "", ErrInvalidFlags
+	}
+
 	res := &createResponse{}
 	_, err = c.request(opCreate, &CreateRequest{path, data, acl, createMode.toFlag()}, res, nil)
 	if err == ErrConnectionClosed {

--- a/conn.go
+++ b/conn.go
@@ -1060,16 +1060,16 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 		return "", err
 	}
 
-	if err := validatePath(path, createMode.sequential); err != nil {
+	if err := validatePath(path, createMode.isSequential); err != nil {
 		return "", err
 	}
 
 	if createMode.isTTL {
-		return "", ErrInvalidFlags
+		return "", fmt.Errorf("Create with TTL flag disallowed :%w", ErrInvalidFlags)
 	}
 
 	res := &createResponse{}
-	_, err = c.request(opCreate, &CreateRequest{path, data, acl, createMode.toFlag()}, res, nil)
+	_, err = c.request(opCreate, &CreateRequest{path, data, acl, createMode.flag}, res, nil)
 	if err == ErrConnectionClosed {
 		return "", err
 	}
@@ -1086,16 +1086,16 @@ func (c *Conn) CreateContainer(path string, data []byte, flag int32, acl []ACL) 
 		return "", err
 	}
 
-	if err := validatePath(path, createMode.sequential); err != nil {
+	if err := validatePath(path, createMode.isSequential); err != nil {
 		return "", err
 	}
 
 	if !createMode.isContainer {
-		return "", ErrInvalidFlags
+		return "", fmt.Errorf("CreateContainer requires container flag :%w", ErrInvalidFlags)
 	}
 
 	res := &createResponse{}
-	_, err = c.request(opCreateContainer, &CreateRequest{path, data, acl, createMode.toFlag()}, res, nil)
+	_, err = c.request(opCreateContainer, &CreateRequest{path, data, acl, createMode.flag}, res, nil)
 	return res.Path, err
 }
 
@@ -1106,16 +1106,16 @@ func (c *Conn) CreateTTL(path string, data []byte, flag int32, acl []ACL, ttl ti
 		return "", err
 	}
 
-	if err := validatePath(path, createMode.sequential); err != nil {
+	if err := validatePath(path, createMode.isSequential); err != nil {
 		return "", err
 	}
 
 	if !createMode.isTTL {
-		return "", ErrInvalidFlags
+		return "", fmt.Errorf("CreateTTL requires TTL flag :%w", ErrInvalidFlags)
 	}
 
 	res := &createResponse{}
-	_, err = c.request(opCreateTTL, &CreateTTLRequest{path, data, acl, createMode.toFlag(), ttl.Milliseconds()}, res, nil)
+	_, err = c.request(opCreateTTL, &CreateTTLRequest{path, data, acl, createMode.flag, ttl.Milliseconds()}, res, nil)
 	return res.Path, err
 }
 

--- a/conn.go
+++ b/conn.go
@@ -1065,7 +1065,7 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 	}
 
 	if createMode.isTTL {
-		return "", fmt.Errorf("Create with TTL flag disallowed :%w", ErrInvalidFlags)
+		return "", fmt.Errorf("Create with TTL flag disallowed: %w", ErrInvalidFlags)
 	}
 
 	res := &createResponse{}
@@ -1091,7 +1091,7 @@ func (c *Conn) CreateContainer(path string, data []byte, flag int32, acl []ACL) 
 	}
 
 	if !createMode.isContainer {
-		return "", fmt.Errorf("CreateContainer requires container flag :%w", ErrInvalidFlags)
+		return "", fmt.Errorf("CreateContainer requires container flag: %w", ErrInvalidFlags)
 	}
 
 	res := &createResponse{}
@@ -1111,7 +1111,7 @@ func (c *Conn) CreateTTL(path string, data []byte, flag int32, acl []ACL, ttl ti
 	}
 
 	if !createMode.isTTL {
-		return "", fmt.Errorf("CreateTTL requires TTL flag :%w", ErrInvalidFlags)
+		return "", fmt.Errorf("CreateTTL requires TTL flag: %w", ErrInvalidFlags)
 	}
 
 	res := &createResponse{}

--- a/conn.go
+++ b/conn.go
@@ -1055,12 +1055,17 @@ func (c *Conn) Set(path string, data []byte, version int32) (*Stat, error) {
 // same as the input, for example when creating a sequence znode the returned path
 // will be the input path with a sequence number appended.
 func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string, error) {
-	if err := validatePath(path, flags&FlagSequence == FlagSequence); err != nil {
+	createMode, err := parseCreateMode(flags)
+	if err != nil {
+		return "", err
+	}
+
+	if err := validatePath(path, createMode.sequential); err != nil {
 		return "", err
 	}
 
 	res := &createResponse{}
-	_, err := c.request(opCreate, &CreateRequest{path, data, acl, flags}, res, nil)
+	_, err = c.request(opCreate, &CreateRequest{path, data, acl, createMode.toFlag()}, res, nil)
 	if err == ErrConnectionClosed {
 		return "", err
 	}
@@ -1068,30 +1073,45 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 }
 
 // CreateContainer creates a container znode and returns the path.
-func (c *Conn) CreateContainer(path string, data []byte, flags int32, acl []ACL) (string, error) {
-	if err := validatePath(path, flags&FlagSequence == FlagSequence); err != nil {
+//
+// Containers cannot be ephemeral or sequential, or have TTLs.
+// Ensure that we reject flags for TTL, Sequence, and Ephemeral.
+func (c *Conn) CreateContainer(path string, data []byte, flag int32, acl []ACL) (string, error) {
+	createMode, err := parseCreateMode(flag)
+	if err != nil {
 		return "", err
 	}
-	if flags&FlagTTL != FlagTTL {
+
+	if err := validatePath(path, createMode.sequential); err != nil {
+		return "", err
+	}
+
+	if !createMode.isContainer {
 		return "", ErrInvalidFlags
 	}
 
 	res := &createResponse{}
-	_, err := c.request(opCreateContainer, &CreateContainerRequest{path, data, acl, flags}, res, nil)
+	_, err = c.request(opCreateContainer, &CreateRequest{path, data, acl, createMode.toFlag()}, res, nil)
 	return res.Path, err
 }
 
 // CreateTTL creates a TTL znode, which will be automatically deleted by server after the TTL.
-func (c *Conn) CreateTTL(path string, data []byte, flags int32, acl []ACL, ttl time.Duration) (string, error) {
-	if err := validatePath(path, flags&FlagSequence == FlagSequence); err != nil {
+func (c *Conn) CreateTTL(path string, data []byte, flag int32, acl []ACL, ttl time.Duration) (string, error) {
+	createMode, err := parseCreateMode(flag)
+	if err != nil {
 		return "", err
 	}
-	if flags&FlagTTL != FlagTTL {
+
+	if err := validatePath(path, createMode.sequential); err != nil {
+		return "", err
+	}
+
+	if !createMode.isTTL {
 		return "", ErrInvalidFlags
 	}
 
 	res := &createResponse{}
-	_, err := c.request(opCreateTTL, &CreateTTLRequest{path, data, acl, flags, ttl.Milliseconds()}, res, nil)
+	_, err = c.request(opCreateTTL, &CreateTTLRequest{path, data, acl, createMode.toFlag(), ttl.Milliseconds()}, res, nil)
 	return res.Path, err
 }
 

--- a/constants.go
+++ b/constants.go
@@ -75,13 +75,6 @@ const (
 	StateHasSession = State(101)
 )
 
-const (
-	// FlagEphemeral means the node is ephemeral.
-	FlagEphemeral = 1
-	FlagSequence  = 2
-	FlagTTL       = 4
-)
-
 var (
 	stateNames = map[State]string{
 		StateUnknown:           "StateUnknown",

--- a/create_mode.go
+++ b/create_mode.go
@@ -2,6 +2,7 @@ package zk
 
 import "fmt"
 
+// TODO: (v2) enum type for CreateMode API.
 const (
 	FlagPersistent                  = 0
 	FlagEphemeral                   = 1
@@ -13,15 +14,11 @@ const (
 )
 
 type createMode struct {
-	flag        int32
-	ephemeral   bool
-	sequential  bool
-	isContainer bool
-	isTTL       bool
-}
-
-func (cm *createMode) toFlag() int32 {
-	return cm.flag
+	flag         int32
+	isEphemeral  bool
+	isSequential bool
+	isContainer  bool
+	isTTL        bool
 }
 
 // parsing a flag integer into the CreateMode needed to call the correct

--- a/create_mode.go
+++ b/create_mode.go
@@ -1,0 +1,52 @@
+package zk
+
+import "fmt"
+
+const (
+	FlagPersistent                  = 0
+	FlagEphemeral                   = 1
+	FlagSequence                    = 2
+	FlagEphemeralSequential         = 3
+	FlagContainer                   = 4
+	FlagTTL                         = 5
+	FlagPersistentSequentialWithTTL = 6
+)
+
+type createMode struct {
+	flag        int32
+	ephemeral   bool
+	sequential  bool
+	isContainer bool
+	isTTL       bool
+}
+
+func (cm *createMode) toFlag() int32 {
+	return cm.flag
+}
+
+// parsing a flag integer into the CreateMode needed to call the correct
+// Create RPC to Zookeeper.
+//
+// NOTE: This parse method is designed to be able to copy and paste the same
+// CreateMode ENUM constructors from Java:
+// https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
+func parseCreateMode(flag int32) (createMode, error) {
+	switch flag {
+	case FlagPersistent:
+		return createMode{0, false, false, false, false}, nil
+	case FlagEphemeral:
+		return createMode{1, true, false, false, false}, nil
+	case FlagSequence:
+		return createMode{2, false, true, false, false}, nil
+	case FlagEphemeralSequential:
+		return createMode{3, true, true, false, false}, nil
+	case FlagContainer:
+		return createMode{4, false, false, true, false}, nil
+	case FlagTTL:
+		return createMode{5, false, false, false, true}, nil
+	case FlagPersistentSequentialWithTTL:
+		return createMode{6, false, true, false, true}, nil
+	default:
+		return createMode{}, fmt.Errorf("invalid flag value: [%v]", flag)
+	}
+}

--- a/create_mode_test.go
+++ b/create_mode_test.go
@@ -22,7 +22,7 @@ func TestParseCreateMode(t *testing.T) {
 	for _, tt := range changeDetectorTests {
 		t.Run(tt.name, func(t *testing.T) {
 			cm, err := parseCreateMode(tt.flag)
-			requireNoError(t, err)
+			requireNoErrorf(t, err)
 			if cm.toFlag() != tt.wantIntValue {
 				// change detector test for enum values.
 				t.Fatalf("createmode value of flag; want: %v, got: %v", cm.toFlag(), tt.wantIntValue)

--- a/create_mode_test.go
+++ b/create_mode_test.go
@@ -23,9 +23,9 @@ func TestParseCreateMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cm, err := parseCreateMode(tt.flag)
 			requireNoErrorf(t, err)
-			if cm.toFlag() != tt.wantIntValue {
+			if cm.flag != tt.wantIntValue {
 				// change detector test for enum values.
-				t.Fatalf("createmode value of flag; want: %v, got: %v", cm.toFlag(), tt.wantIntValue)
+				t.Fatalf("createmode value of flag; want: %v, got: %v", cm.flag, tt.wantIntValue)
 			}
 		})
 	}

--- a/create_mode_test.go
+++ b/create_mode_test.go
@@ -1,0 +1,43 @@
+package zk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCreateMode(t *testing.T) {
+	changeDetectorTests := []struct {
+		name         string
+		flag         int32
+		wantIntValue int32
+	}{
+		{"valid flag createmode 0 persistant", FlagPersistent, 0},
+		{"ephemeral", FlagEphemeral, 1},
+		{"sequential", FlagSequence, 2},
+		{"ephemeral sequential", FlagEphemeralSequential, 3},
+		{"container", FlagContainer, 4},
+		{"ttl", FlagTTL, 5},
+		{"persistentSequential w/TTL", FlagPersistentSequentialWithTTL, 6},
+	}
+	for _, tt := range changeDetectorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm, err := parseCreateMode(tt.flag)
+			requireNoError(t, err)
+			if cm.toFlag() != tt.wantIntValue {
+				// change detector test for enum values.
+				t.Fatalf("createmode value of flag; want: %v, got: %v", cm.toFlag(), tt.wantIntValue)
+			}
+		})
+	}
+
+	t.Run("failed to parse", func(t *testing.T) {
+		cm, err := parseCreateMode(-123)
+		if err == nil {
+			t.Fatalf("error expected, got: %v", cm)
+		}
+		if !strings.Contains(err.Error(), "invalid flag value") {
+			t.Fatalf("unexpected error value: %v", err)
+		}
+	})
+
+}

--- a/structs.go
+++ b/structs.go
@@ -166,8 +166,6 @@ type CreateRequest struct {
 	Flags int32
 }
 
-type CreateContainerRequest CreateRequest
-
 type CreateTTLRequest struct {
 	Path  string
 	Data  []byte
@@ -598,10 +596,8 @@ func requestStructForOp(op int32) interface{} {
 	switch op {
 	case opClose:
 		return &closeRequest{}
-	case opCreate:
+	case opCreate, opCreateContainer:
 		return &CreateRequest{}
-	case opCreateContainer:
-		return &CreateContainerRequest{}
 	case opCreateTTL:
 		return &CreateTTLRequest{}
 	case opDelete:

--- a/zk_test.go
+++ b/zk_test.go
@@ -136,14 +136,14 @@ func TestIntegration_CreateTTL(t *testing.T) {
 	const testPath = "/ttl_znode_tests"
 	// create sub node to create per test in avoiding using the root path.
 	_, err = zk.Create(testPath, nil /* data */, FlagPersistent, WorldACL(PermAll))
-	requireNoError(t, err)
+	requireNoErrorf(t, err)
 
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := filepath.Join(testPath, fmt.Sprint(idx))
 			_, err := zk.CreateTTL(path, []byte{12}, tt.createFlags, WorldACL(PermAll), tt.giveDuration)
 			if tt.wantErr == "" {
-				requireNoError(t, err, fmt.Sprintf("error not expected: path; %q; flags %v", path, tt.createFlags))
+				requireNoErrorf(t, err, fmt.Sprintf("error not expected: path; %q; flags %v", path, tt.createFlags))
 				return
 			}
 
@@ -223,14 +223,14 @@ func TestIntegration_CreateContainer(t *testing.T) {
 	const testPath = "/container_test_znode"
 	// create sub node to create per test in avoiding using the root path.
 	_, err = zk.Create(testPath, nil /* data */, FlagPersistent, WorldACL(PermAll))
-	requireNoError(t, err)
+	requireNoErrorf(t, err)
 
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := filepath.Join(testPath, fmt.Sprint(idx))
 			_, err := zk.CreateContainer(path, []byte{12}, tt.createFlags, WorldACL(PermAll))
 			if tt.wantErr == "" {
-				requireNoError(t, err, fmt.Sprintf("error not expected: path; %q; flags %v", path, tt.createFlags))
+				requireNoErrorf(t, err, fmt.Sprintf("error not expected: path; %q; flags %v", path, tt.createFlags))
 				return
 			}
 


### PR DESCRIPTION
BREAKING Client behavior: since this proposes a new parsing of the Create flag integer this will break clients if they rely on CreateContainer as it was creating znodes that may not have been containers.

Changes:
- Fix FlagTTL value from 4 -> 5
- Adding all known CreateMode values to Flag constants.
- Adding a createMode private struct behind the flag integer, replicate CreateMode from ZK java lib.
- Create, CreateContainer, CreateTTL methods now parse the flag integer passed in based on the constants defined (new error condition).
- Rewrite tests to better catch CreateContainer and CreateTTL (no assertions on zk behavior since zk does not expose znode mode)
- Added Change-Detector unit tests for create mode values.