### PR TITLE
Add in support for a TryLock to attempt to get a lock within a timeout

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -124,6 +124,7 @@ var (
 	ErrSessionMoved            = errors.New("zk: session moved to another server, so operation is ignored")
 	ErrReconfigDisabled        = errors.New("attempts to perform a reconfiguration operation when reconfiguration feature is disabled")
 	ErrBadArguments            = errors.New("invalid arguments")
+	ErrTimeout                 = errors.New("timeout exceeded")
 	// ErrInvalidCallback         = errors.New("zk: invalid callback specified")
 
 	errCodeToError = map[ErrCode]error{
@@ -144,6 +145,7 @@ var (
 		errSessionMoved:      ErrSessionMoved,
 		errZReconfigDisabled: ErrReconfigDisabled,
 		errBadArguments:      ErrBadArguments,
+		errTimeout:           ErrTimeout,
 	}
 )
 
@@ -166,6 +168,7 @@ const (
 	errOperationTimeout     = -7
 	errBadArguments         = -8
 	errInvalidState         = -9
+	errTimeout              = -10
 	// API errors
 	errAPIError                ErrCode = -100
 	errNoNode                  ErrCode = -101 // *


### PR DESCRIPTION
I was looking for this feature also as we use ZK to assign workers by taking locks if available.

https://github.com/go-zookeeper/zk/issues/116
