### PR TITLE
add dns host provider lookup timeout

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -191,7 +191,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 	ec := make(chan Event, eventChanSize)
 	conn := &Conn{
 		dialer:         net.DialTimeout,
-		hostProvider:   &DNSHostProvider{},
+		hostProvider:   NewDNSHostProvider(),
 		conn:           nil,
 		state:          StateDisconnected,
 		eventChan:      ec,

--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -1,8 +1,8 @@
 package zk
 
 import (
-	"fmt"
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -37,12 +37,12 @@ func (o lookupTimeoutOption) apply(provider *DNSHostProvider) {
 // the call to Init.  It could be easily extended to re-query DNS
 // periodically or if there is trouble connecting.
 type DNSHostProvider struct {
-	mu         sync.Mutex // Protects everything, so we can add asynchronous updates later.
-	servers    []string
-	curr       int
-	last       int
+	mu            sync.Mutex // Protects everything, so we can add asynchronous updates later.
+	servers       []string
+	curr          int
+	last          int
 	lookupTimeout time.Duration
-	lookupHost lookupHostFn // Override of net.LookupHost, for testing.
+	lookupHost    lookupHostFn // Override of net.LookupHost, for testing.
 }
 
 // NewDNSHostProvider creates a new DNSHostProvider with the given options.

--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -50,7 +50,7 @@ type DNSHostProvider struct {
 func NewDNSHostProvider(options ...DNSHostProviderOption) *DNSHostProvider {
 	var provider DNSHostProvider
 	for _, option := range options {
-		option(&provider)
+		option.apply(&provider)
 	}
 	return &provider
 }

--- a/dnshostprovider.go
+++ b/dnshostprovider.go
@@ -32,7 +32,6 @@ func (o lookupTimeoutOption) apply(provider *DNSHostProvider) {
 	provider.lookupTimeout = o.timeout
 }
 
-
 // DNSHostProvider is the default HostProvider. It currently matches
 // the Java StaticHostProvider, resolving hosts from DNS once during
 // the call to Init.  It could be easily extended to re-query DNS

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -34,7 +34,7 @@ func TestIntegration_DNSHostProviderCreate(t *testing.T) {
 	port := ts.Servers[0].Port
 	server := fmt.Sprintf("foo.example.com:%d", port)
 	hostProvider := NewDNSHostProvider(
-		withLookupHost(func (ctx context.Context, host string) ([]string, error) {
+		withLookupHost(func(ctx context.Context, host string) ([]string, error) {
 			if _, ok := ctx.Deadline(); !ok {
 				t.Fatal("No lookup context deadline set")
 			}
@@ -245,7 +245,7 @@ func TestDNSHostProviderRetryStart(t *testing.T) {
 }
 
 func TestNewDNSHostProvider(t *testing.T) {
-	want := 5*time.Second
+	want := 5 * time.Second
 	provider := NewDNSHostProvider(WithLookupTimeout(want))
 	if provider.lookupTimeout != want {
 		t.Fatalf("expected lookup timeout to be %v, got %v", want, provider.lookupTimeout)

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -8,10 +8,18 @@ import (
 	"time"
 )
 
-func withLookupHost(lookupFn func(context.Context, string) ([]string, error)) DNSHostProviderOption {
-	return func(provider *DNSHostProvider) {
-		provider.lookupHost = lookupFn
+type lookupHostOption struct {
+	lookupFn lookupHostFn
+}
+
+func withLookupHost(lookupFn lookupHostFn) DNSHostProviderOption {
+	return lookupHostOption{
+		lookupFn: lookupFn,
 	}
+}
+
+func (o lookupHostOption) apply(provider *DNSHostProvider) {
+	provider.lookupHost = o.lookupFn
 }
 
 // TestDNSHostProviderCreate is just like TestCreate, but with an

--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -1,16 +1,17 @@
 package zk
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
 	"time"
 )
 
-// localhostLookupHost is a test replacement for net.LookupHost that
-// always returns 127.0.0.1
-func localhostLookupHost(host string) ([]string, error) {
-	return []string{"127.0.0.1"}, nil
+func withLookupHost(lookupFn func(context.Context, string) ([]string, error)) DNSHostProviderOption {
+	return func(provider *DNSHostProvider) {
+		provider.lookupHost = lookupFn
+	}
 }
 
 // TestDNSHostProviderCreate is just like TestCreate, but with an
@@ -24,7 +25,15 @@ func TestIntegration_DNSHostProviderCreate(t *testing.T) {
 
 	port := ts.Servers[0].Port
 	server := fmt.Sprintf("foo.example.com:%d", port)
-	hostProvider := &DNSHostProvider{lookupHost: localhostLookupHost}
+	hostProvider := NewDNSHostProvider(
+		withLookupHost(func (ctx context.Context, host string) ([]string, error) {
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatal("No lookup context deadline set")
+			}
+			return []string{"127.0.0.1"}, nil
+		}),
+	)
+
 	zk, _, err := Connect([]string{server}, time.Second*15, WithHostProvider(hostProvider))
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
@@ -103,9 +112,11 @@ func TestIntegration_DNSHostProviderReconnect(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	innerHp := &DNSHostProvider{lookupHost: func(host string) ([]string, error) {
-		return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
-	}}
+	innerHp := NewDNSHostProvider(
+		withLookupHost(func(_ context.Context, host string) ([]string, error) {
+			return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
+		}),
+	)
 	ports := make([]int, 0, len(ts.Servers))
 	for _, server := range ts.Servers {
 		ports = append(ports, server.Port)
@@ -172,9 +183,11 @@ func TestIntegration_DNSHostProviderReconnect(t *testing.T) {
 func TestDNSHostProviderRetryStart(t *testing.T) {
 	t.Parallel()
 
-	hp := &DNSHostProvider{lookupHost: func(host string) ([]string, error) {
-		return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
-	}}
+	hp := NewDNSHostProvider(
+		withLookupHost(func(_ context.Context, host string) ([]string, error) {
+			return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
+		}),
+	)
 
 	if err := hp.Init([]string{"foo.example.com:12345"}); err != nil {
 		t.Fatal(err)
@@ -220,5 +233,13 @@ func TestDNSHostProviderRetryStart(t *testing.T) {
 		if td.callConnected {
 			hp.Connected()
 		}
+	}
+}
+
+func TestNewDNSHostProvider(t *testing.T) {
+	want := 5*time.Second
+	provider := NewDNSHostProvider(WithLookupTimeout(want))
+	if provider.lookupTimeout != want {
+		t.Fatalf("expected lookup timeout to be %v, got %v", want, provider.lookupTimeout)
 	}
 }


### PR DESCRIPTION
Resolves #142 by adding a 3s timeout for DNS lookups. This is better behavior than having the call get stuck indefinitely when the DNS resolver isn't reachable.

Adjusted/added unit tests to verify.
```
$ go test -run ^TestNewDNSHostProvider$
PASS
ok      github.com/go-zookeeper/zk      0.207s
```