### PR TITLE
Fix for dnshostprovider to be able to skip this DNS failure in case o…

### DIFF
--- a/dnshostprovider_test.go
+++ b/dnshostprovider_test.go
@@ -251,3 +251,10 @@ func TestNewDNSHostProvider(t *testing.T) {
 		t.Fatalf("expected lookup timeout to be %v, got %v", want, provider.lookupTimeout)
 	}
 }
+
+func TestNewDNSHostProviderWithIgnore(t *testing.T) {
+	provider := NewDNSHostProvider(WithIgnoreDNSErrors())
+	if provider.ignoreDNSFailures != true {
+		t.Fatalf("expected ignoreDNSFailures to be true, got %v", provider.ignoreDNSFailures)
+	}
+}


### PR DESCRIPTION
You could have 5-10-15 zookeepers and any dns issue with resolve will lead to failure of this ZK lib. Which totaly destroys all idea of having multiple nodes inside zookeeper.

This code doesn't change current logic but extend option for dns resolver to be able to disable this error and keep working