### PR TITLE
add initial assertion library

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,51 @@
+// Internal assertion library inspired by https://github.com/stretchr/testify.
+// "A little copying is better than a little dependency." - https://go-proverbs.github.io.
+// We don't want the library to have dependencies, so we write our own assertions.
+package assert
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// TestingT is an interface wrapper around stdlib *testing.T.
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	Helper()
+}
+
+// Equal asserts that expected is equal to actual.
+func Equal(t TestingT, want, got interface{}, msgAndArgs ...interface{}) {
+	if !reflect.DeepEqual(want, got) {
+		fail(t, fmt.Sprintf("not equal: want: %+v, got: %+v", want, got), msgAndArgs)
+	}
+}
+
+// NoError asserts that the error is nil.
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if err != nil {
+		fail(t, fmt.Sprintf("unexpected error: %v", err), msgAndArgs)
+	}
+}
+
+func fail(t TestingT, message string, msgAndArgs []interface{}) {
+	t.Helper()
+	userMessage := msgAndArgsToString(msgAndArgs)
+	if userMessage != "" {
+		message += ": " + userMessage
+	}
+	t.Errorf(message)
+}
+
+func msgAndArgsToString(msgAndArgs []interface{}) string {
+	if len(msgAndArgs) == 0 {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		return fmt.Sprintf("%+v", msgAndArgs[0])
+	}
+	if format, ok := msgAndArgs[0].(string); ok {
+		return fmt.Sprintf(format, msgAndArgs[1:]...)
+	}
+	return fmt.Sprintf("%+v", msgAndArgs)
+}

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1,0 +1,160 @@
+package assert
+
+import (
+	"errors"
+	"testing"
+)
+
+type call struct {
+	name string
+	args []interface{}
+}
+
+// fakeT is a fake implementation of TestingT.
+// It records calls to its methods.
+// Its methods are not safe for concurrent use.
+type fakeT struct {
+	calls []call
+}
+
+func (f *fakeT) Errorf(format string, args ...interface{}) {
+	f.calls = append(f.calls, call{
+		name: "Errorf",
+		args: append([]interface{}{format}, args...),
+	})
+}
+
+func (f *fakeT) Helper() {
+	f.calls = append(f.calls, call{name: "Helper"})
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name           string
+		giveWant       interface{}
+		giveGot        interface{}
+		giveMsgAndArgs []interface{}
+		want           []call
+	}{
+		{
+			name:     "equal",
+			giveWant: 1,
+			giveGot:  1,
+			want:     nil,
+		},
+		{
+			name:     "not equal shallow",
+			giveWant: 1,
+			giveGot:  2,
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"not equal: want: 1, got: 2"}},
+			},
+		},
+		{
+			name:     "not equal deep",
+			giveWant: map[string]interface{}{"foo": struct{ bar string }{"baz"}},
+			giveGot:  map[string]interface{}{"foo": struct{ bar string }{"foobar"}},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"not equal: want: map[foo:{bar:baz}], got: map[foo:{bar:foobar}]"}},
+			},
+		},
+		{
+			name:           "with message",
+			giveWant:       1,
+			giveGot:        2,
+			giveMsgAndArgs: []interface{}{"user message"},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"not equal: want: 1, got: 2: user message"}},
+			},
+		},
+		{
+			name:           "with message and args",
+			giveWant:       1,
+			giveGot:        2,
+			giveMsgAndArgs: []interface{}{"user message: %d %s", 1, "arg2"},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"not equal: want: 1, got: 2: user message: 1 arg2"}},
+			},
+		},
+		{
+			name:           "only args",
+			giveWant:       1,
+			giveGot:        2,
+			giveMsgAndArgs: []interface{}{1, "arg2"},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"not equal: want: 1, got: 2: [1 arg2]"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f fakeT
+			Equal(&f, tt.giveWant, tt.giveGot, tt.giveMsgAndArgs...)
+			// Since we're asserting ourselves it might be possible to introduce a subtle bug.
+			// However, the code is straightforward so it's not a big deal.
+			Equal(t, tt.want, f.calls)
+		})
+	}
+}
+
+func TestNoError(t *testing.T) {
+	tests := []struct {
+		name           string
+		giveErr        error
+		giveMsgAndArgs []interface{}
+		want           []call
+	}{
+		{
+			name:    "no error",
+			giveErr: nil,
+			want:    nil,
+		},
+		{
+			name:    "with error",
+			giveErr: errors.New("foo"),
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"unexpected error: foo"}},
+			},
+		},
+		{
+			name:           "with message",
+			giveErr:        errors.New("foo"),
+			giveMsgAndArgs: []interface{}{"user message"},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"unexpected error: foo: user message"}},
+			},
+		},
+		{
+			name:           "with message and args",
+			giveErr:        errors.New("foo"),
+			giveMsgAndArgs: []interface{}{"user message: %d %s", 1, "arg2"},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"unexpected error: foo: user message: 1 arg2"}},
+			},
+		},
+		{
+			name:           "only args",
+			giveErr:        errors.New("foo"),
+			giveMsgAndArgs: []interface{}{1, "arg2"},
+			want: []call{
+				{name: "Helper"},
+				{name: "Errorf", args: []interface{}{"unexpected error: foo: [1 arg2]"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f fakeT
+			NoError(&f, tt.giveErr, tt.giveMsgAndArgs...)
+			Equal(t, tt.want, f.calls)
+		})
+	}
+}


### PR DESCRIPTION
Adds initial test assertion library. Closes #147 and more context in the issue.

This PR just introduces the library to make reviews easier. It will be used in another PR after this.

Unit tested.

```
$ make unittest
=== RUN   TestEqual
=== RUN   TestEqual/equal
=== RUN   TestEqual/not_equal_shallow
=== RUN   TestEqual/not_equal_deep
=== RUN   TestEqual/with_message
=== RUN   TestEqual/with_message_and_args
=== RUN   TestEqual/only_args
--- PASS: TestEqual (0.00s)
    --- PASS: TestEqual/equal (0.00s)
    --- PASS: TestEqual/not_equal_shallow (0.00s)
    --- PASS: TestEqual/not_equal_deep (0.00s)
    --- PASS: TestEqual/with_message (0.00s)
    --- PASS: TestEqual/with_message_and_args (0.00s)
    --- PASS: TestEqual/only_args (0.00s)
=== RUN   TestNoError
=== RUN   TestNoError/no_error
=== RUN   TestNoError/with_error
=== RUN   TestNoError/with_message
=== RUN   TestNoError/with_message_and_args
=== RUN   TestNoError/only_args
--- PASS: TestNoError (0.00s)
    --- PASS: TestNoError/no_error (0.00s)
    --- PASS: TestNoError/with_error (0.00s)
    --- PASS: TestNoError/with_message (0.00s)
    --- PASS: TestNoError/with_message_and_args (0.00s)
    --- PASS: TestNoError/only_args (0.00s)
PASS
coverage: 100.0% of statements
ok      github.com/go-zookeeper/zk/internal/assert      1.371s  coverage: 100.0% of statements
```
